### PR TITLE
Add ccip_sdk tool to chainlink-ccip-skill

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Root
-* @zeuslawyer @andrejrakic @thodges-gh @Nalon @smartcontractkit/devrel
+* @andrejrakic @thodges-gh @Nalon @smartcontractkit/devrel

--- a/chainlink-ccip-skill/SKILL.md
+++ b/chainlink-ccip-skill/SKILL.md
@@ -5,6 +5,7 @@ license: MIT
 compatibility: Designed for AI agents that implement https://agentskills.io/specification, including Claude Code, Cursor Composer, and Codex-style workflows.
 metadata:
   version: "0.0.1"
+  mcp-server: "@chainlink/mcp-server"
 ---
 
 # Chainlink CCIP Skill
@@ -18,22 +19,24 @@ Route CCIP requests to the simplest valid path while keeping side effects tightl
 1. Keep this file as the default guide.
 2. Read [references/user-stories.md](references/user-stories.md) only when the request is ambiguous or you need routing examples.
 3. Read [references/official-sources.md](references/official-sources.md) only when the answer depends on live CCIP facts, current tool behavior, route or token availability, or message-status surfaces.
-4. Read [references/ccip-tools.md](references/ccip-tools.md) only when the user wants a tool-first workflow through CCIP CLI, API, or SDK.
-5. Read [references/ccip-contracts.md](references/ccip-contracts.md) only when the user wants sender or receiver contracts, token-transfer contracts, programmable token-transfer contracts, or contract setup help.
-6. Read [references/ccip-cct.md](references/ccip-cct.md) only when the user wants to create a token, register it as a CCT, configure pools, set rate limits, or add networks for CCT operation.
-7. Read [references/chainlink-local.md](references/chainlink-local.md) only when the user wants local simulation, local tests, or forked-environment testing for CCIP contracts.
-8. Read [references/ccip-monitoring.md](references/ccip-monitoring.md) only when the user wants message lookup, monitoring, status explanation, lane performance, or failed-message diagnosis.
-9. Read [references/ccip-discovery.md](references/ccip-discovery.md) only when the user wants route connectivity checks, network classification, or supported-token discovery.
-10. Do not load reference files speculatively.
+4. Read [references/ccip-mcp.md](references/ccip-mcp.md) only when the `ccip_sdk` MCP tool is available and the request can be fulfilled by it for monitoring, discovery, or SDK method calls.
+5. Read [references/ccip-tools.md](references/ccip-tools.md) only when the user wants a tool-first workflow through CCIP CLI, API, or SDK.
+6. Read [references/ccip-contracts.md](references/ccip-contracts.md) only when the user wants sender or receiver contracts, token-transfer contracts, programmable token-transfer contracts, or contract setup help.
+7. Read [references/ccip-cct.md](references/ccip-cct.md) only when the user wants to create a token, register it as a CCT, configure pools, set rate limits, or add networks for CCT operation.
+8. Read [references/chainlink-local.md](references/chainlink-local.md) only when the user wants local simulation, local tests, or forked-environment testing for CCIP contracts.
+9. Read [references/ccip-monitoring.md](references/ccip-monitoring.md) only when the user wants message lookup, monitoring, status explanation, lane performance, or failed-message diagnosis.
+10. Read [references/ccip-discovery.md](references/ccip-discovery.md) only when the user wants route connectivity checks, network classification, or supported-token discovery.
+11. Do not load reference files speculatively.
 
 ## Routing
 
 1. Use a tool-first path for sending without custom contracts, bridging funds, status lookup, connectivity checks, and route or token discovery.
-2. Use a contract-first path for sender and receiver contract work and CCT setup flows.
-3. Ask one focused question if the route, network, token, amount, or target contracts are missing.
-4. Proceed without approval only for read-only work such as explanation, discovery, status checks, and code generation.
-5. Trigger the approval protocol before any action that could create, transfer, deploy, register, enable, or configure on-chain state.
-6. Do not assume this skill is the only capability available. Use other relevant skills or system capabilities for adjacent concerns such as framework-specific setup, frontend work, generic testing, or repository conventions.
+2. When the `ccip_sdk` MCP tool is available, prefer it over direct CLI or SDK invocation for monitoring, discovery, and programmatic SDK method calls. Fall back to CLI or SDK when the tool is not available.
+3. Use a contract-first path for sender and receiver contract work and CCT setup flows.
+4. Ask one focused question if the route, network, token, amount, or target contracts are missing.
+5. Proceed without approval only for read-only work such as explanation, discovery, status checks, and code generation.
+6. Trigger the approval protocol before any action that could create, transfer, deploy, register, enable, or configure on-chain state.
+7. Do not assume this skill is the only capability available. Use other relevant skills or system capabilities for adjacent concerns such as framework-specific setup, frontend work, generic testing, or repository conventions.
 
 ## Safety Guardrails
 

--- a/chainlink-ccip-skill/references/ccip-contracts.md
+++ b/chainlink-ccip-skill/references/ccip-contracts.md
@@ -66,6 +66,10 @@ Important behaviors from the official references:
 4. `IRouterClient.isChainSupported` can be used to verify chain support.
 5. If tokens and data are sent to an EOA receiver, only the tokens arrive.
 
+## Testnet Tokens
+
+For testnet contract-first flows, the standard test token is **CCIP-BnM** (burn-and-mint). It is the token provided by the Chainlink faucet and used in official CCIP tutorials. When generating or testing token-transfer contracts on a testnet, use CCIP-BnM as the default token unless the user specifies otherwise.
+
 ## Contract Workflow
 
 ### Data-only contracts
@@ -119,6 +123,8 @@ If CCIP imports pull in OpenZeppelin contracts, install the exact versions requi
 @openzeppelin/contracts@4.8.3/=lib/openzeppelin-contracts-4.8.3/contracts/
 @openzeppelin/contracts@5.3.0/=lib/openzeppelin-contracts-5.3.0/contracts/
 ```
+
+`CCIPReceiver` itself imports `IERC165` from OpenZeppelin, and the version it expects may differ from the OZ version used elsewhere in the project. For example, `CCIPReceiver` may require `@openzeppelin/contracts@5.0.2` while other CCIP or Chainlink contracts require `4.8.3` or `5.3.0`. Check the actual import paths in the installed CCIP contracts (grep for `@openzeppelin` in `lib/chainlink-ccip/`) to determine which versions are needed, and add separate remappings for each.
 
 Additional remappings may be required in projects that also depend on Chainlink ACE or related packages:
 

--- a/chainlink-ccip-skill/references/ccip-discovery.md
+++ b/chainlink-ccip-skill/references/ccip-discovery.md
@@ -17,8 +17,8 @@ Do not use this workflow for message status, lane-performance monitoring, direct
 ## Default Path
 
 1. Prefer the CCIP Directory as the primary source of truth for route existence, network classification, and supported tokens.
-2. When the `ccip_sdk` MCP tool is available, use it with `target='api'` as a complementary source for route and token discovery queries. See [ccip-mcp.md](ccip-mcp.md) for tool parameters and workflow patterns.
-3. Use CLI `get-supported-tokens` only as a complementary check when the user has concrete router or network context and command-line output would help.
+2. When the `ccip_sdk` MCP tool is available, use it with `target='api'` as an additional source for route and token discovery queries. See [ccip-mcp.md](ccip-mcp.md) for tool parameters and workflow patterns.
+3. Use CLI `get-supported-tokens` only as an additional check when the user has concrete router or network context and command-line output would help.
 4. Use CCIP Tools documentation only when the request depends on current tool behavior rather than the directory itself.
 5. If the user is actually asking about current lane performance instead of route existence, route to [ccip-monitoring.md](ccip-monitoring.md).
 
@@ -46,7 +46,7 @@ Reference points:
 ### Token support
 
 1. Use the CCIP Directory first for supported-token discovery on a route.
-2. If the user has a router or pool context and wants command-level verification, use CLI `get-supported-tokens` as a complementary path.
+2. If the user has a router or pool context and wants command-level verification, use CLI `get-supported-tokens` as an additional path.
 3. Distinguish clearly between:
    - route exists but token unsupported
    - route missing entirely

--- a/chainlink-ccip-skill/references/ccip-discovery.md
+++ b/chainlink-ccip-skill/references/ccip-discovery.md
@@ -17,9 +17,10 @@ Do not use this workflow for message status, lane-performance monitoring, direct
 ## Default Path
 
 1. Prefer the CCIP Directory as the primary source of truth for route existence, network classification, and supported tokens.
-2. Use CLI `get-supported-tokens` only as a complementary check when the user has concrete router or network context and command-line output would help.
-3. Use CCIP Tools documentation only when the request depends on current tool behavior rather than the directory itself.
-4. If the user is actually asking about current lane performance instead of route existence, route to [ccip-monitoring.md](ccip-monitoring.md).
+2. When the `ccip_sdk` MCP tool is available, use it with `target='api'` as a complementary source for route and token discovery queries. See [ccip-mcp.md](ccip-mcp.md) for tool parameters and workflow patterns.
+3. Use CLI `get-supported-tokens` only as a complementary check when the user has concrete router or network context and command-line output would help.
+4. Use CCIP Tools documentation only when the request depends on current tool behavior rather than the directory itself.
+5. If the user is actually asking about current lane performance instead of route existence, route to [ccip-monitoring.md](ccip-monitoring.md).
 
 Reference points:
 

--- a/chainlink-ccip-skill/references/ccip-mcp.md
+++ b/chainlink-ccip-skill/references/ccip-mcp.md
@@ -1,0 +1,194 @@
+# CCIP MCP
+
+Use this file only when the `ccip_sdk` MCP tool is available and the request can be fulfilled by it.
+
+## Trigger Conditions
+
+Use this workflow for requests like:
+
+- "Check the status of my CCIP message using the MCP server."
+- "Use the SDK to get lane latency for this route."
+- "What methods are available on the CCIP API client?"
+- "Read my CCIP token balance on this chain."
+- "Get the fee estimate for this transfer using the SDK."
+
+Do not use this workflow when the MCP server is not connected. Fall back to direct CLI or SDK usage from [ccip-tools.md](ccip-tools.md) instead.
+
+## MCP Server
+
+- Package: `@chainlink/mcp-server`
+- Transport: stdio
+- The server name in the host configuration (Cursor, Claude Code, etc.) is set by the developer and may vary. The tool name `ccip_sdk` is stable regardless of what the server is named.
+
+## ccip_sdk Tool
+
+Unified CCIP SDK tool. Use `target='api'` for `CCIPAPIClient` calls (message status, lane latency) or `target='chain'` for on-chain reads via RPC (balances, fees). Provide method name and args array. For chain calls, include `family` and `rpcUrl`. Use strings for large integers (chain selectors) to avoid precision loss. Set `listMethods=true` to discover available methods.
+
+### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `target` | `"api"` or `"chain"` | Yes | `api` for CCIPAPIClient calls, `chain` for on-chain reads via RPC. |
+| `method` | string | Yes, unless `listMethods` is true | SDK method name to invoke on the target. |
+| `args` | array | No | Positional arguments for the method. Use strings for large integers. |
+| `listMethods` | boolean | No | When true, returns available method names for the target instead of calling a method. |
+| `family` | `"evm"`, `"solana"`, `"aptos"`, `"sui"`, or `"ton"` | Required for `chain` target | Chain family for on-chain calls. |
+| `rpcUrl` | string (URL) | Required for `chain` target unless a default exists | RPC URL for the source chain. Defaults exist for `evm` (Sepolia), `solana` (devnet), and `aptos` (testnet). |
+| `baseUrl` | string (URL) | No | Override for the CCIP API base URL. Defaults to `https://api.ccip.chain.link`. |
+
+### Validation Rules
+
+1. `method` is required unless `listMethods` is true.
+2. For `target='chain'`, `family` is always required.
+3. For `target='chain'`, `rpcUrl` must be provided unless the family has a built-in default (`evm`, `solana`, `aptos`).
+4. Pass chain selectors as strings, not numbers, to avoid JavaScript precision loss.
+
+## Workflow Patterns
+
+### Discover available methods
+
+Before calling a method, use `listMethods` to see what is available on the target.
+
+For API methods:
+
+```json
+{
+  "target": "api",
+  "listMethods": true
+}
+```
+
+For chain methods on a specific family:
+
+```json
+{
+  "target": "chain",
+  "family": "evm",
+  "listMethods": true
+}
+```
+
+### Message status lookup
+
+Use `target='api'` with the appropriate retrieval method and the message ID or transaction hash.
+
+```json
+{
+  "target": "api",
+  "method": "getMessageById",
+  "args": ["0x<64-hex-message-id>"]
+}
+```
+
+### Lane latency
+
+Pass chain selectors as strings to preserve precision.
+
+```json
+{
+  "target": "api",
+  "method": "getLaneLatency",
+  "args": ["<source-chain-selector>", "<destination-chain-selector>"]
+}
+```
+
+### On-chain reads
+
+Use `target='chain'` with the chain family and an RPC URL. Discover methods first, then call the relevant one.
+
+```json
+{
+  "target": "chain",
+  "family": "evm",
+  "rpcUrl": "https://ethereum-sepolia-rpc.publicnode.com",
+  "method": "<method-name>",
+  "args": []
+}
+```
+
+## Default Path
+
+1. Start with `listMethods` to discover available methods on the target before guessing method names.
+2. Use `target='api'` for monitoring, message retrieval, lane latency, and other API-backed queries.
+3. Use `target='chain'` for on-chain reads such as balances, fees, and contract state.
+4. Pass chain selectors as strings to avoid precision loss on large integers.
+5. If MCP is not connected or a call fails with a connection error, fall back to direct CLI or SDK invocation and follow [ccip-tools.md](ccip-tools.md).
+
+## Error Handling
+
+### MCP connection failure
+
+If the `ccip_sdk` tool is not available or returns a connection error:
+1. Confirm the MCP server providing the `ccip_sdk` tool is connected in the host environment.
+2. Fall back to direct CLI or SDK usage from [ccip-tools.md](ccip-tools.md).
+
+### Invalid parameters
+
+If the tool returns a validation error:
+1. Check that `method` is provided (or `listMethods` is true).
+2. For `chain` target, check that `family` and `rpcUrl` are provided.
+3. For `getLaneLatency`, check that chain selectors are passed as strings.
+
+### Unknown method
+
+If the tool returns "Unknown CCIP SDK method":
+1. Call the tool with `listMethods=true` for the same target to get available method names.
+2. Retry with the correct method name.
+
+## Freshness Rules
+
+1. The MCP server loads CCIP configuration at startup. Treat its responses as current.
+2. For questions about live message status or current lane performance, prefer MCP over cached assumptions.
+3. Read [official-sources.md](official-sources.md) when the answer depends on sources beyond what the MCP tool covers.
+
+## Refusal Rules
+
+1. All safety guardrails, approval protocols, and mainnet-write restrictions from the main skill file still apply when using MCP tools.
+2. Do not treat MCP tool availability as a bypass for the approval or second-confirmation requirements.
+3. If the MCP tool would execute a side-effecting action, require the same approval flow as direct CLI or SDK execution.
+
+## Triggering Tests
+
+These prompts should trigger this workflow when the `ccip_sdk` tool is available:
+
+- "Use the CCIP SDK tool to check the status of this message."
+- "List the available methods on the CCIP API client."
+- "Get lane latency for Ethereum Sepolia to Base Sepolia using the MCP tool."
+- "Read my token balance on this chain using the CCIP SDK."
+
+These prompts should not trigger this workflow:
+
+- "Write a CCIP sender contract in Solidity."
+- "Explain how CCIP works at a high level."
+- "Add Chainlink Local tests for this receiver."
+- "Bridge funds using the CLI." (explicit CLI preference)
+
+## Functional Tests
+
+1. If the `ccip_sdk` tool is available and the user asks for message status, use `target='api'` instead of directing to CLI or API docs.
+2. If the user asks to discover available methods, call with `listMethods=true` before attempting a method call.
+3. If the user provides chain selectors as numbers, convert them to strings before calling `getLaneLatency`.
+4. If the `ccip_sdk` tool returns an unknown method error, retry with `listMethods=true` to discover the correct name.
+5. If the `ccip_sdk` tool is not available, fall back to CLI or SDK without error.
+6. If the request involves a side-effecting action through MCP, require the same approval and second-confirmation flow.
+7. If the user explicitly asks for CLI or direct SDK usage, do not override with MCP.
+
+## Eval Checks
+
+The workflow passes if it:
+
+1. prefers the `ccip_sdk` MCP tool when available for supported operations
+2. falls back gracefully to CLI or SDK when MCP is not available
+3. uses `listMethods` for method discovery instead of guessing
+4. passes chain selectors as strings for precision safety
+5. preserves all safety guardrails and approval protocols when using MCP
+6. does not override an explicit user preference for CLI or direct SDK
+
+## A/B Prompt Pack
+
+Use these prompts with and without the `ccip_sdk` MCP tool available:
+
+1. "Check the status of this CCIP message ID and explain what state it is in."
+2. "What methods can I call on the CCIP API client? List them for me."
+3. "Get the lane latency between Ethereum Sepolia and Base Sepolia and tell me whether it looks healthy."
+4. "Read my CCIP-related balance on Ethereum Sepolia using the SDK."

--- a/chainlink-ccip-skill/references/ccip-monitoring.md
+++ b/chainlink-ccip-skill/references/ccip-monitoring.md
@@ -19,7 +19,7 @@ Do not use this workflow for contract generation or direct send/bridge execution
 1. When the `ccip_sdk` MCP tool is available, prefer it with `target='api'` for message retrieval, lane latency, and query workflows. See [ccip-mcp.md](ccip-mcp.md) for tool parameters and workflow patterns.
 2. Prefer the CCIP API docs for monitoring and query workflows when MCP is not connected.
 3. Use the CCIP CLI when the user wants direct command-line tracking, search, lane latency, or failed-message debugging.
-4. Use explorer-style lookup only when the user explicitly wants an explorer view or the API/CLI path is less convenient.
+4. If the MCP tool, API, or CLI path does not return a result or returns an error, fall back to the CCIP Explorer (`https://ccip.chain.link/`). The Explorer is the most reliable interactive surface for message status today.
 5. Do not switch to side-effecting remediation unless the user explicitly asks for it.
 
 Reference points:
@@ -65,6 +65,19 @@ Prefer the CLI for:
 Treat `manual-exec` as a separate side-effecting operation, not as a default monitoring action.
 
 ## Monitoring Workflow
+
+### Extracting a message ID from a transaction receipt
+
+After a CCIP send (via `cast send`, a contract call, or any on-chain submission), the CCIP message ID is emitted in the transaction logs. It is not returned directly by the send call.
+
+To extract it:
+
+1. Get the transaction receipt (e.g. `cast receipt <tx-hash>`).
+2. Look for the `CCIPSendRequested` event in the logs. For token transfers, also check the `TokensSent` event.
+3. The message ID is in the event topics (typically `topics[1]` for `CCIPSendRequested`, or a field in the log data depending on the CCIP version).
+4. If using `cast`, parse the relevant log entry from the receipt output. The message ID is a 32-byte hex value (`0x` followed by 64 hex characters).
+
+If log parsing is not practical, the transaction hash itself can be used with the CCIP Explorer, CLI `show`, or MCP/API lookup to find the associated message.
 
 ### Message lookup
 

--- a/chainlink-ccip-skill/references/ccip-monitoring.md
+++ b/chainlink-ccip-skill/references/ccip-monitoring.md
@@ -16,10 +16,11 @@ Do not use this workflow for contract generation or direct send/bridge execution
 
 ## Default Path
 
-1. Prefer the CCIP API for monitoring, querying, and message lookup workflows.
-2. Use the CCIP CLI when the user wants direct command-line tracking, search, lane latency, or failed-message debugging.
-3. Use explorer-style lookup only when the user explicitly wants an explorer view or the API/CLI path is less convenient.
-4. Do not switch to side-effecting remediation unless the user explicitly asks for it.
+1. When the `ccip_sdk` MCP tool is available, prefer it with `target='api'` for message retrieval, lane latency, and query workflows. See [ccip-mcp.md](ccip-mcp.md) for tool parameters and workflow patterns.
+2. Prefer the CCIP API docs for monitoring and query workflows when MCP is not connected.
+3. Use the CCIP CLI when the user wants direct command-line tracking, search, lane latency, or failed-message debugging.
+4. Use explorer-style lookup only when the user explicitly wants an explorer view or the API/CLI path is less convenient.
+5. Do not switch to side-effecting remediation unless the user explicitly asks for it.
 
 Reference points:
 
@@ -28,6 +29,16 @@ Reference points:
 - Explorer: `https://ccip.chain.link/`
 
 ## Core Monitoring Surfaces
+
+### ccip_sdk MCP Tool
+
+When the MCP server is connected, prefer the `ccip_sdk` tool with `target='api'` for:
+
+1. retrieving a message by ID or transaction hash
+2. lane latency queries (pass chain selectors as strings)
+3. programmatic monitoring integrations that benefit from structured MCP responses
+
+Use `listMethods=true` with `target='api'` to discover all available monitoring methods. Fall back to the CCIP API or CLI paths below when MCP is not connected.
 
 ### CCIP API
 

--- a/chainlink-ccip-skill/references/ccip-monitoring.md
+++ b/chainlink-ccip-skill/references/ccip-monitoring.md
@@ -70,7 +70,7 @@ Treat `manual-exec` as a separate side-effecting operation, not as a default mon
 
 1. Identify what the user has: tx hash, message ID, sender, route, or wallet.
 2. If the user has a tx hash or message ID and wants direct tracking, use the CLI or API retrieve-message path.
-3. If the user wants search or listing, prefer the API and use CLI search as a complementary path.
+3. If the user wants search or listing, prefer the API and use CLI search as an additional path.
 4. Explain the lifecycle state clearly instead of only returning raw data.
 
 ### Lane checks

--- a/chainlink-ccip-skill/references/ccip-tools.md
+++ b/chainlink-ccip-skill/references/ccip-tools.md
@@ -28,10 +28,11 @@ If the route or network is missing, ask for it. Do not assume a lane.
 
 ## Default Path
 
-1. Prefer the CCIP CLI for side-effecting on-chain actions such as fee estimation, sending, token support checks, and manual execution.
-2. Use the CCIP SDK only when the user asks for a programmatic integration or code sample.
-3. Route read-only monitoring, querying, searching, lane-latency checks, and message-status workflows to [ccip-monitoring.md](ccip-monitoring.md).
-4. Do not switch to contract generation unless the user asks for it or the tool-first path cannot satisfy the goal.
+1. When the `ccip_sdk` MCP tool is available, prefer it for programmatic SDK and API operations such as fee estimation, message status, lane latency, and on-chain reads. See [ccip-mcp.md](ccip-mcp.md) for tool parameters and workflow patterns.
+2. Prefer the CCIP CLI for side-effecting on-chain actions such as sending, token support checks, and manual execution when MCP is not connected or the action is not supported by the MCP tool.
+3. Use the CCIP SDK directly only when the user asks for a programmatic integration, code sample, or MCP is not available.
+4. Route read-only monitoring, querying, searching, lane-latency checks, and message-status workflows to [ccip-monitoring.md](ccip-monitoring.md).
+5. Do not switch to contract generation unless the user asks for it or the tool-first path cannot satisfy the goal.
 
 Reference points:
 - CLI docs: `https://docs.chain.link/ccip/tools/cli/`

--- a/chainlink-ccip-skill/references/ccip-tools.md
+++ b/chainlink-ccip-skill/references/ccip-tools.md
@@ -41,6 +41,10 @@ Reference points:
 - CLI package: `@chainlink/ccip-cli`
 - SDK package: `@chainlink/ccip-sdk`
 
+## Testnet Tokens
+
+For testnet flows, the standard test token is **CCIP-BnM** (burn-and-mint). It is the token provided by the Chainlink faucet and used in official CCIP tutorials. When the user is working on a testnet and has not specified a token, suggest CCIP-BnM as the default. LINK and WETH are also available on some testnet routes but CCIP-BnM is the most common starting point.
+
 ## Send and Bridge Workflow
 
 ### For token transfers


### PR DESCRIPTION
- Adds MCP server integration to the CCIP skill, enabling the ccip_sdk tool from @chainlink/mcp-server as the preferred path for programmatic CCIP operations (monitoring, discovery, on-chain reads) when available.
- Creates a new references/ccip-mcp.md with the full tool schema, workflow patterns, error handling, and fallback guidance.
- Updates ccip-tools.md, ccip-monitoring.md, and ccip-discovery.md to route through MCP when the tool is available, with CLI/SDK as fallback.