### PR TITLE
Update ccip-mcp to match MCP updates

### DIFF
--- a/chainlink-ccip-skill/references/ccip-mcp.md
+++ b/chainlink-ccip-skill/references/ccip-mcp.md
@@ -22,14 +22,16 @@ Do not use this workflow when the MCP server is not connected. Fall back to dire
 
 ## ccip_sdk Tool
 
-Unified CCIP SDK tool. Use `target='api'` for `CCIPAPIClient` calls (message status, lane latency) or `target='chain'` for on-chain reads via RPC (balances, fees). Provide method name and args array. For chain calls, include `family` and `rpcUrl`. Use strings for large integers (chain selectors) to avoid precision loss. Set `listMethods=true` to discover available methods.
+Unified CCIP SDK tool. For message status lookups, use the `messageId` or `sourceTxHash` shortcut fields — these bypass `target`/`method` dispatch and always return a standardized response. For all other operations, use `target='api'` for `CCIPAPIClient` calls (lane latency, discovery) or `target='chain'` for on-chain reads via RPC (balances, fees). Provide method name and args array. For chain calls, include `family` and `rpcUrl`. Use strings for large integers (chain selectors) to avoid precision loss. Set `listMethods=true` to discover available methods.
 
 ### Parameters
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `target` | `"api"` or `"chain"` | Yes | `api` for CCIPAPIClient calls, `chain` for on-chain reads via RPC. |
-| `method` | string | Yes, unless `listMethods` is true | SDK method name to invoke on the target. |
+| `messageId` | string (hex) | No | Shortcut: directly fetch status for this message ID. Bypasses `target`/`method` dispatch. `target` is not required. |
+| `sourceTxHash` | string (hex) | No | Shortcut: resolve message IDs from this transaction hash, then fetch status for each. Bypasses `target`/`method` dispatch. `target` is not required. |
+| `target` | `"api"` or `"chain"` | Required unless using `messageId` or `sourceTxHash` | `api` for CCIPAPIClient calls, `chain` for on-chain reads via RPC. |
+| `method` | string | Required unless `listMethods` is true or using a shortcut field | SDK method name to invoke on the target. |
 | `args` | array | No | Positional arguments for the method. Use strings for large integers. |
 | `listMethods` | boolean | No | When true, returns available method names for the target instead of calling a method. |
 | `family` | `"evm"`, `"solana"`, `"aptos"`, `"sui"`, or `"ton"` | Required for `chain` target | Chain family for on-chain calls. |
@@ -38,10 +40,40 @@ Unified CCIP SDK tool. Use `target='api'` for `CCIPAPIClient` calls (message sta
 
 ### Validation Rules
 
-1. `method` is required unless `listMethods` is true.
-2. For `target='chain'`, `family` is always required.
-3. For `target='chain'`, `rpcUrl` must be provided unless the family has a built-in default (`evm`, `solana`, `aptos`).
-4. Pass chain selectors as strings, not numbers, to avoid JavaScript precision loss.
+1. `method` is required unless `listMethods` is true or a shortcut field (`messageId`, `sourceTxHash`) is provided.
+2. `target` is not required when `messageId` or `sourceTxHash` is provided.
+3. For `target='chain'`, `family` is always required.
+4. For `target='chain'`, `rpcUrl` must be provided unless the family has a built-in default (`evm`, `solana`, `aptos`).
+5. Pass chain selectors as strings, not numbers, to avoid JavaScript precision loss.
+
+### Standardized Message Status Response
+
+When using `messageId` or `sourceTxHash`, the tool always returns a normalized shape:
+
+```typescript
+{
+  messageId: "0x...",
+  status: "pending" | "in_transit" | "delivered" | "failed",
+  lifecycleStage: "waiting_for_finality" | "committed" | "blessed" | "executed" | null,
+  sourceChain: "...",
+  destinationChain: "...",
+  sourceTxHash: "0x...",
+  destinationTxHash: "0x..." | null,  // populated when delivered, null otherwise
+  timestamp: "2025-..."
+}
+```
+
+`lifecycleStage` maps all SDK `MessageStatus` values to a named stage:
+
+| SDK status | `status` | `lifecycleStage` |
+|---|---|---|
+| SENT | `pending` | `waiting_for_finality` |
+| SOURCE_FINALIZED | `in_transit` | `waiting_for_finality` |
+| VERIFYING / VERIFIED | `in_transit` | `committed` |
+| COMMITTED | `in_transit` | `committed` |
+| BLESSED | `in_transit` | `blessed` |
+| SUCCESS | `delivered` | `executed` |
+| FAILED | `failed` | `executed` |
 
 ## Workflow Patterns
 
@@ -68,17 +100,27 @@ For chain methods on a specific family:
 }
 ```
 
-### Message status lookup
+### Message status by message ID
 
-Use `target='api'` with the appropriate retrieval method and the message ID or transaction hash.
+Use the `messageId` shortcut. `target` and `method` are not required.
 
 ```json
 {
-  "target": "api",
-  "method": "getMessageById",
-  "args": ["0x<64-hex-message-id>"]
+  "messageId": "0x<64-hex-message-id>"
 }
 ```
+
+### Message status by source transaction hash
+
+Use the `sourceTxHash` shortcut. The tool resolves all message IDs in the transaction, then returns status for each.
+
+```json
+{
+  "sourceTxHash": "0x<transaction-hash>"
+}
+```
+
+Both shortcuts return the [standardized response schema](#standardized-message-status-response).
 
 ### Lane latency
 
@@ -108,11 +150,12 @@ Use `target='chain'` with the chain family and an RPC URL. Discover methods firs
 
 ## Default Path
 
-1. Start with `listMethods` to discover available methods on the target before guessing method names.
-2. Use `target='api'` for monitoring, message retrieval, lane latency, and other API-backed queries.
-3. Use `target='chain'` for on-chain reads such as balances, fees, and contract state.
-4. Pass chain selectors as strings to avoid precision loss on large integers.
-5. If MCP is not connected or a call fails with a connection error, fall back to direct CLI or SDK invocation and follow [ccip-tools.md](ccip-tools.md).
+1. For message status lookups, use the `messageId` or `sourceTxHash` shortcut instead of constructing a `target`/`method` call manually.
+2. Start with `listMethods` to discover available methods on the target before guessing method names for non-shortcut calls.
+3. Use `target='api'` for lane latency, discovery, and other API-backed queries.
+4. Use `target='chain'` for on-chain reads such as balances, fees, and contract state.
+5. Pass chain selectors as strings to avoid precision loss on large integers.
+6. If MCP is not connected or a call fails with a connection error, fall back to direct CLI or SDK invocation and follow [ccip-tools.md](ccip-tools.md).
 
 ## Error Handling
 
@@ -152,6 +195,8 @@ If the tool returns "Unknown CCIP SDK method":
 These prompts should trigger this workflow when the `ccip_sdk` tool is available:
 
 - "Use the CCIP SDK tool to check the status of this message."
+- "Look up this CCIP message by its ID using the MCP server."
+- "I have a source tx hash — fetch the CCIP message status from it."
 - "List the available methods on the CCIP API client."
 - "Get lane latency for Ethereum Sepolia to Base Sepolia using the MCP tool."
 - "Read my token balance on this chain using the CCIP SDK."
@@ -165,30 +210,35 @@ These prompts should not trigger this workflow:
 
 ## Functional Tests
 
-1. If the `ccip_sdk` tool is available and the user asks for message status, use `target='api'` instead of directing to CLI or API docs.
-2. If the user asks to discover available methods, call with `listMethods=true` before attempting a method call.
-3. If the user provides chain selectors as numbers, convert them to strings before calling `getLaneLatency`.
-4. If the `ccip_sdk` tool returns an unknown method error, retry with `listMethods=true` to discover the correct name.
-5. If the `ccip_sdk` tool is not available, fall back to CLI or SDK without error.
-6. If the request involves a side-effecting action through MCP, require the same approval and second-confirmation flow.
-7. If the user explicitly asks for CLI or direct SDK usage, do not override with MCP.
+1. If the `ccip_sdk` tool is available and the user asks for message status by message ID, use the `messageId` shortcut instead of `target='api'` + `method='getMessageById'`.
+2. If the `ccip_sdk` tool is available and the user provides a source transaction hash, use the `sourceTxHash` shortcut to resolve and fetch all messages in the transaction.
+3. When using a shortcut field, do not include `target` or `method` in the call.
+4. If the user asks to discover available methods, call with `listMethods=true` before attempting a method call.
+5. If the user provides chain selectors as numbers, convert them to strings before calling `getLaneLatency`.
+6. If the `ccip_sdk` tool returns an unknown method error, retry with `listMethods=true` to discover the correct name.
+7. If the `ccip_sdk` tool is not available, fall back to CLI or SDK without error.
+8. If the request involves a side-effecting action through MCP, require the same approval and second-confirmation flow.
+9. If the user explicitly asks for CLI or direct SDK usage, do not override with MCP.
 
 ## Eval Checks
 
 The workflow passes if it:
 
 1. prefers the `ccip_sdk` MCP tool when available for supported operations
-2. falls back gracefully to CLI or SDK when MCP is not available
-3. uses `listMethods` for method discovery instead of guessing
-4. passes chain selectors as strings for precision safety
-5. preserves all safety guardrails and approval protocols when using MCP
-6. does not override an explicit user preference for CLI or direct SDK
+2. uses the `messageId` shortcut for message ID lookups instead of manually constructing `target`/`method` calls
+3. uses the `sourceTxHash` shortcut when the user provides a transaction hash for status lookup
+4. falls back gracefully to CLI or SDK when MCP is not available
+5. uses `listMethods` for method discovery instead of guessing
+6. passes chain selectors as strings for precision safety
+7. preserves all safety guardrails and approval protocols when using MCP
+8. does not override an explicit user preference for CLI or direct SDK
 
 ## A/B Prompt Pack
 
 Use these prompts with and without the `ccip_sdk` MCP tool available:
 
 1. "Check the status of this CCIP message ID and explain what state it is in."
-2. "What methods can I call on the CCIP API client? List them for me."
-3. "Get the lane latency between Ethereum Sepolia and Base Sepolia and tell me whether it looks healthy."
-4. "Read my CCIP-related balance on Ethereum Sepolia using the SDK."
+2. "I have a source transaction hash — look up the CCIP message status from it."
+3. "What methods can I call on the CCIP API client? List them for me."
+4. "Get the lane latency between Ethereum Sepolia and Base Sepolia and tell me whether it looks healthy."
+5. "Read my CCIP-related balance on Ethereum Sepolia using the SDK."


### PR DESCRIPTION
Updates with changes from [MCP#88](https://github.com/smartcontractkit/mcp-server/pull/88):

- Parameters table: added messageId and sourceTxHash as top-level shortcut fields; updated target and method to note they're not required when using shortcuts.
- Validation rules: updated rules 1 and 2 to reflect the new shortcut exception logic.
- New section: Standardized Message Status Response: documents the NormalizedMessageStatus shape and the full lifecycleStage mapping table for all SDK MessageStatus values.
- Workflow patterns: replaced the old getMessageById example with separate messageId and sourceTxHash shortcut examples.
- Default Path: reordered to lead with the shortcut preference for message status lookups.
- Triggering tests, Functional tests, Eval Checks, A/B Prompt Pack: all updated to cover the new shortcuts and standardized response.