### PR TITLE
Update skill versions

### DIFF
--- a/chainlink-ccip-skill/SKILL.md
+++ b/chainlink-ccip-skill/SKILL.md
@@ -4,7 +4,7 @@ description: "Handle Chainlink CCIP requests with a safety-first workflow. Use f
 license: MIT
 compatibility: Designed for AI agents that implement https://agentskills.io/specification, including Claude Code, Cursor Composer, and Codex-style workflows.
 metadata:
-  version: "0.0.1"
+  version: "0.0.2"
   mcp-server: "@chainlink/mcp-server"
 ---
 

--- a/chainlink-cre-skill/SKILL.md
+++ b/chainlink-cre-skill/SKILL.md
@@ -6,7 +6,7 @@ compatibility: Designed for Claude Code, Cursor Composer, and AI agents that imp
 allowed-tools: Read WebFetch Write Edit Bash
 metadata:
   purpose: CRE developer onboarding, assistance and reference
-  version: "0.2"
+  version: "0.0.2"
 ---
 
 # Chainlink CRE Skill


### PR DESCRIPTION
- Consolidates versioning to `major.minor.patch`
- Bumps CCIP skill version to `0.0.2` for MCP server additions