### PR TITLE
Allow eval runs from IDE agents

### DIFF
--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -29,6 +29,9 @@ on:
           - chainlink-data-feeds-skill
         default: all
 
+permissions:
+  contents: read
+
 env:
   ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
   OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
@@ -39,18 +42,45 @@ jobs:
     outputs:
       skills: ${{ steps.resolve.outputs.skills }}
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
       - name: Resolve skill matrix
         id: resolve
         run: |
-          SKILL="${{ github.event.inputs.skill || 'all' }}"
-          if [ "$SKILL" = "all" ] || [ "$SKILL" = "" ]; then
-            echo 'skills=["chainlink-ccip-skill","chainlink-cre-skill","chainlink-data-feeds-skill"]' >> "$GITHUB_OUTPUT"
-          else
+          SKILL="${{ github.event.inputs.skill }}"
+
+          if [ -n "$SKILL" ] && [ "$SKILL" != "all" ]; then
             echo "skills=[\"$SKILL\"]" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          ALL_SKILLS=("chainlink-ccip-skill" "chainlink-cre-skill" "chainlink-data-feeds-skill")
+
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            CHANGED=$(git diff --name-only origin/${{ github.base_ref }}...HEAD)
+            MATCHED=()
+            for skill in "${ALL_SKILLS[@]}"; do
+              if echo "$CHANGED" | grep -qE "^(${skill}|evals/${skill})/"; then
+                MATCHED+=("\"$skill\"")
+              fi
+            done
+            if [ ${#MATCHED[@]} -eq 0 ]; then
+              echo "No skill-specific files changed; skipping evals."
+              echo 'skills=[]' >> "$GITHUB_OUTPUT"
+            else
+              JOINED=$(IFS=,; echo "${MATCHED[*]}")
+              echo "skills=[$JOINED]" >> "$GITHUB_OUTPUT"
+            fi
+          else
+            echo 'skills=["chainlink-ccip-skill","chainlink-cre-skill","chainlink-data-feeds-skill"]' >> "$GITHUB_OUTPUT"
           fi
 
   eval:
     needs: detect-skills
+    if: ${{ needs.detect-skills.outputs.skills != '[]' }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -1,0 +1,104 @@
+name: Skill Evals
+
+on:
+  pull_request:
+    paths:
+      - "chainlink-ccip-skill/**"
+      - "chainlink-cre-skill/**"
+      - "chainlink-data-feeds-skill/**"
+      - "evals/**"
+  workflow_dispatch:
+    inputs:
+      tier:
+        description: "Eval tier to run"
+        type: choice
+        options:
+          - smoke
+          - full
+        default: smoke
+      skill:
+        description: "Skill to evaluate (blank = all)"
+        type: choice
+        options:
+          - all
+          - chainlink-ccip-skill
+          - chainlink-cre-skill
+          - chainlink-data-feeds-skill
+        default: all
+
+env:
+  ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+  OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+
+jobs:
+  detect-skills:
+    runs-on: ubuntu-latest
+    outputs:
+      skills: ${{ steps.resolve.outputs.skills }}
+    steps:
+      - name: Resolve skill matrix
+        id: resolve
+        run: |
+          SKILL="${{ github.event.inputs.skill || 'all' }}"
+          if [ "$SKILL" = "all" ] || [ "$SKILL" = "" ]; then
+            echo 'skills=["chainlink-ccip-skill","chainlink-cre-skill","chainlink-data-feeds-skill"]' >> "$GITHUB_OUTPUT"
+          else
+            echo "skills=[\"$SKILL\"]" >> "$GITHUB_OUTPUT"
+          fi
+
+  eval:
+    needs: detect-skills
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        skill: ${{ fromJson(needs.detect-skills.outputs.skills) }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install promptfoo
+        run: npm install -g promptfoo
+
+      - name: Resolve tier
+        id: tier
+        run: |
+          TIER="${{ github.event.inputs.tier || 'smoke' }}"
+          echo "tier=$TIER" >> "$GITHUB_OUTPUT"
+
+      - name: Run eval
+        working-directory: evals/${{ matrix.skill }}
+        run: |
+          TIER="${{ steps.tier.outputs.tier }}"
+          if [ "$TIER" = "smoke" ]; then
+            promptfoo eval --filter-metadata "smoke=true" --no-cache
+          else
+            promptfoo eval --no-cache
+          fi
+
+      - name: Generate report
+        if: always()
+        working-directory: evals/${{ matrix.skill }}
+        run: |
+          promptfoo export -o results.json || true
+          if [ -f results.json ]; then
+            echo "### ${{ matrix.skill }} eval results" >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            promptfoo export -o results.csv || true
+            TOTAL=$(jq '.results.stats.successes + .results.stats.failures' results.json 2>/dev/null || echo "?")
+            PASS=$(jq '.results.stats.successes' results.json 2>/dev/null || echo "?")
+            echo "**Pass rate**: ${PASS}/${TOTAL}" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: eval-results-${{ matrix.skill }}
+          path: evals/${{ matrix.skill }}/results.*
+          if-no-files-found: ignore

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -1,5 +1,8 @@
 name: Skill Evals
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     paths:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,36 @@ Skills follow the [Agent Skills specification](https://agentskills.io/specificat
 - `allowed-tools`
 - `metadata.version` - Semver string
 
+## Running Evals
+
+Each skill has an eval suite in `evals/<skill-name>/` containing test cases, grading rubrics, and a promptfoo config.
+
+### With API keys (promptfoo)
+
+If `ANTHROPIC_API_KEY` and `OPENAI_API_KEY` are set in `.env`:
+
+```
+source .env
+cd evals/<skill-name>
+npx promptfoo eval
+npx promptfoo view
+```
+
+### Without API keys (agent-powered)
+
+Read and follow the protocol in `evals/run-agent-eval.md`. This runs generation and grading entirely through Cursor subagents. Ask:
+
+```
+Run agent evals for chainlink-ccip-skill
+Run agent evals for chainlink-data-feeds-skill, functional cases only
+```
+
+### When to run evals
+
+- After modifying a skill's `SKILL.md` or `references/`
+- Before bumping the skill's patch version
+- When adding new eval cases (to verify they pass)
+
 ## Conventions
 
 - Do not commit `.env` or secret files.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,24 @@ Skills follow the [Agent Skills specification](https://agentskills.io/specificat
 
 ## Running Evals
 
-Each skill has an eval suite in `evals/<skill-name>/` containing test cases, grading rubrics, and a promptfoo config.
+Each skill has an eval suite in `evals/<skill-name>/` containing test cases, grading rubrics, and a promptfoo config. Evals are organized into tiers:
+
+| Tier | Cases | Method | When to use |
+|------|-------|--------|-------------|
+| Smoke | ~20 | Agent-powered or promptfoo | Quick feedback during development, PR CI gate |
+| Full | All 95 | Promptfoo | Before releases, after major refactors, scheduled CI |
+
+Cases included in the smoke tier are tagged with `smoke: true` in their `metadata` block in the promptfoo configs.
+
+### Agent-powered (no API keys needed)
+
+Read and follow the protocol in `evals/run-agent-eval.md`. This runs generation and grading entirely through Cursor subagents. Smoke tier is the default:
+
+```
+Run agent evals for chainlink-ccip-skill
+Run agent evals for chainlink-ccip-skill, full suite
+Run agent evals for chainlink-data-feeds-skill, functional cases only
+```
 
 ### With API keys (promptfoo)
 
@@ -39,24 +56,19 @@ If `ANTHROPIC_API_KEY` and `OPENAI_API_KEY` are set in `.env`:
 ```
 source .env
 cd evals/<skill-name>
-npx promptfoo eval
+npx promptfoo eval --filter-metadata "smoke=true"   # smoke tier
+npx promptfoo eval                                    # full suite
 npx promptfoo view
 ```
 
-### Without API keys (agent-powered)
+### CI (GitHub Actions)
 
-Read and follow the protocol in `evals/run-agent-eval.md`. This runs generation and grading entirely through Cursor subagents. Ask:
-
-```
-Run agent evals for chainlink-ccip-skill
-Run agent evals for chainlink-data-feeds-skill, functional cases only
-```
+The `eval.yml` workflow runs the smoke tier automatically on PRs that touch skill or eval files. It uses `CI_ANTHROPIC_API_KEY` and `CI_OPENAI_API_KEY` secrets (separate from dev keys to avoid contention). Full suite can be triggered manually via workflow dispatch.
 
 ### When to run evals
 
-- After modifying a skill's `SKILL.md` or `references/`
-- Before bumping the skill's patch version
-- When adding new eval cases (to verify they pass)
+- **Smoke**: After any change to a skill's `SKILL.md` or `references/`, before bumping patch version, when adding new eval cases
+- **Full**: Before releases, after major refactors, or when smoke passes but you want full confidence
 
 ## Conventions
 

--- a/evals/chainlink-ccip-skill/promptfooconfig.yaml
+++ b/evals/chainlink-ccip-skill/promptfooconfig.yaml
@@ -103,6 +103,7 @@ tests:
       workflow: cct
       category: functional
       requiresApproval: yes
+      smoke: true
     assert: *functional_asserts
   - description: functional / cct / cct-02
     vars:
@@ -151,6 +152,7 @@ tests:
       workflow: chainlink-local
       category: functional
       requiresApproval: no
+      smoke: true
     assert: *functional_asserts
   - description: functional / chainlink-local / chainlink-local-02
     vars:
@@ -211,6 +213,7 @@ tests:
       workflow: contract-first
       category: functional
       requiresApproval: no
+      smoke: true
     assert: *functional_asserts
   - description: functional / contract-first / contract-first-02
     vars:
@@ -283,6 +286,7 @@ tests:
       workflow: discovery
       category: functional
       requiresApproval: no
+      smoke: true
     assert: *functional_asserts
   - description: functional / discovery / discovery-02
     vars:
@@ -331,6 +335,7 @@ tests:
       workflow: monitoring
       category: functional
       requiresApproval: no
+      smoke: true
     assert: *functional_asserts
   - description: functional / monitoring / monitoring-02
     vars:
@@ -379,6 +384,7 @@ tests:
       workflow: tool-first
       category: functional
       requiresApproval: yes
+      smoke: true
     assert: *functional_asserts
   - description: functional / tool-first / tool-first-02
     vars:
@@ -427,6 +433,7 @@ tests:
       workflow: cct
       category: trigger-negative
       requiresApproval: yes
+      smoke: true
     assert: *trigger_negative_asserts
   - description: trigger-negative / cct / cct-neg-02
     vars:
@@ -571,6 +578,7 @@ tests:
       workflow: cct
       category: trigger-positive
       requiresApproval: yes
+      smoke: true
     assert: *trigger_positive_asserts
   - description: trigger-positive / cct / cct-02
     vars:
@@ -643,6 +651,7 @@ tests:
       workflow: contract-first
       category: trigger-positive
       requiresApproval: no
+      smoke: true
     assert: *trigger_positive_asserts
   - description: trigger-positive / contract-first / contract-first-02
     vars:
@@ -715,6 +724,7 @@ tests:
       workflow: monitoring
       category: trigger-positive
       requiresApproval: no
+      smoke: true
     assert: *trigger_positive_asserts
   - description: trigger-positive / monitoring / monitoring-02
     vars:
@@ -788,6 +798,7 @@ tests:
       workflow: tool-first
       category: functional
       requiresApproval: yes
+      smoke: true
     assert: *functional_asserts
   - description: functional / messy / messy-tool-first-02
     vars:
@@ -873,6 +884,7 @@ tests:
       workflow: tool-first
       category: trigger-negative
       requiresApproval: no
+      smoke: true
     assert: *trigger_negative_asserts
   - description: trigger-negative / near-miss / near-miss-bridge-02
     vars:

--- a/evals/chainlink-cre-skill/promptfooconfig.yaml
+++ b/evals/chainlink-cre-skill/promptfooconfig.yaml
@@ -53,6 +53,10 @@ tests:
       case_file: cases/functional/workflow-generation-01.txt
       workflow: workflow-generation
       requires_live_source: "no"
+    metadata:
+      workflow: workflow-generation
+      category: functional
+      smoke: true
     assert: *functional_asserts
 
   - vars:
@@ -66,6 +70,10 @@ tests:
       case_file: cases/functional/http-client-01.txt
       workflow: http-client
       requires_live_source: "no"
+    metadata:
+      workflow: http-client
+      category: functional
+      smoke: true
     assert: *functional_asserts
 
   - vars:
@@ -79,6 +87,10 @@ tests:
       case_file: cases/functional/evm-client-01.txt
       workflow: evm-client
       requires_live_source: "no"
+    metadata:
+      workflow: evm-client
+      category: functional
+      smoke: true
     assert: *functional_asserts
 
   - vars:
@@ -92,6 +104,10 @@ tests:
       case_file: cases/functional/triggers-01.txt
       workflow: triggers
       requires_live_source: "no"
+    metadata:
+      workflow: triggers
+      category: functional
+      smoke: true
     assert: *functional_asserts
 
   # ── Functional: Secrets ─────────────────────────────────────────────
@@ -99,6 +115,10 @@ tests:
       case_file: cases/functional/secrets-01.txt
       workflow: secrets
       requires_live_source: "no"
+    metadata:
+      workflow: secrets
+      category: functional
+      smoke: true
     assert: *functional_asserts
 
   # ── Functional: Getting Started ─────────────────────────────────────
@@ -120,6 +140,10 @@ tests:
       case_file: cases/functional/concepts-01.txt
       workflow: concepts
       requires_live_source: "no"
+    metadata:
+      workflow: concepts
+      category: functional
+      smoke: true
     assert: *functional_asserts
 
   - vars:
@@ -133,6 +157,10 @@ tests:
       case_file: cases/trigger-positive/workflow-gen-01.txt
       workflow: workflow-generation
       expected_trigger: "yes"
+    metadata:
+      workflow: workflow-generation
+      category: trigger-positive
+      smoke: true
     assert: *trigger_positive_asserts
 
   - vars:
@@ -145,6 +173,10 @@ tests:
       case_file: cases/trigger-positive/evm-client-01.txt
       workflow: evm-client
       expected_trigger: "yes"
+    metadata:
+      workflow: evm-client
+      category: trigger-positive
+      smoke: true
     assert: *trigger_positive_asserts
 
   - vars:
@@ -182,12 +214,20 @@ tests:
       case_file: cases/trigger-negative/ccip-01.txt
       workflow: none
       expected_trigger: "no"
+    metadata:
+      workflow: none
+      category: trigger-negative
+      smoke: true
     assert: *trigger_negative_asserts
 
   - vars:
       case_file: cases/trigger-negative/data-feeds-01.txt
       workflow: none
       expected_trigger: "no"
+    metadata:
+      workflow: none
+      category: trigger-negative
+      smoke: true
     assert: *trigger_negative_asserts
 
   - vars:

--- a/evals/chainlink-data-feeds-skill/promptfooconfig.yaml
+++ b/evals/chainlink-data-feeds-skill/promptfooconfig.yaml
@@ -53,6 +53,10 @@ tests:
       case_file: cases/functional/reading-price-feeds-01.txt
       workflow: reading-price-feeds
       requires_live_source: "yes"
+    metadata:
+      workflow: reading-price-feeds
+      category: functional
+      smoke: true
     assert: *functional_asserts
 
   - vars:
@@ -78,6 +82,10 @@ tests:
       case_file: cases/functional/mvr-feeds-01.txt
       workflow: mvr-feeds
       requires_live_source: "no"
+    metadata:
+      workflow: mvr-feeds
+      category: functional
+      smoke: true
     assert: *functional_asserts
 
   - vars:
@@ -91,6 +99,10 @@ tests:
       case_file: cases/functional/svr-feeds-01.txt
       workflow: svr-feeds
       requires_live_source: "no"
+    metadata:
+      workflow: svr-feeds
+      category: functional
+      smoke: true
     assert: *functional_asserts
 
   # ── Functional: Feed Types ───────────────────────────────────────────
@@ -105,6 +117,10 @@ tests:
       case_file: cases/functional/multi-chain-01.txt
       workflow: multi-chain
       requires_live_source: "no"
+    metadata:
+      workflow: multi-chain
+      category: functional
+      smoke: true
     assert: *functional_asserts
 
   - vars:
@@ -131,6 +147,10 @@ tests:
       case_file: cases/trigger-positive/reading-price-feeds-01.txt
       workflow: reading-price-feeds
       expected_trigger: "yes"
+    metadata:
+      workflow: reading-price-feeds
+      category: trigger-positive
+      smoke: true
     assert: *trigger_positive_asserts
 
   - vars:
@@ -143,6 +163,10 @@ tests:
       case_file: cases/trigger-positive/mvr-01.txt
       workflow: mvr-feeds
       expected_trigger: "yes"
+    metadata:
+      workflow: mvr-feeds
+      category: trigger-positive
+      smoke: true
     assert: *trigger_positive_asserts
 
   - vars:
@@ -180,12 +204,20 @@ tests:
       case_file: cases/trigger-negative/ccip-01.txt
       workflow: none
       expected_trigger: "no"
+    metadata:
+      workflow: none
+      category: trigger-negative
+      smoke: true
     assert: *trigger_negative_asserts
 
   - vars:
       case_file: cases/trigger-negative/vrf-01.txt
       workflow: none
       expected_trigger: "no"
+    metadata:
+      workflow: none
+      category: trigger-negative
+      smoke: true
     assert: *trigger_negative_asserts
 
   - vars:

--- a/evals/run-agent-eval.md
+++ b/evals/run-agent-eval.md
@@ -1,0 +1,125 @@
+# Agent-Powered Eval Protocol
+
+This runbook lets you run skill evals entirely through Cursor subagents, with no external API keys required.
+
+## Quick Start
+
+Ask the agent:
+
+```
+Run agent evals for chainlink-ccip-skill
+```
+
+Or with filters:
+
+```
+Run agent evals for chainlink-data-feeds-skill, functional cases only
+```
+
+## How It Works
+
+The agent reads this protocol and executes it. The flow uses cross-model grading to avoid self-evaluation bias:
+
+1. **Generate** (default/parent model): A subagent reads the skill's `SKILL.md` as system context + an eval case as the user prompt, then produces a response.
+2. **Grade** (fast model): A separate subagent grades the response against each applicable rubric. Using a different model for grading provides an independent evaluation.
+3. **Report**: Results are collected into a summary table.
+
+## Protocol (for the agent)
+
+When asked to run agent evals, follow these steps exactly.
+
+### Step 1: Resolve inputs
+
+- **skill**: The skill directory name (e.g., `chainlink-ccip-skill`).
+- **category filter** (optional): One of `functional`, `trigger-positive`, `trigger-negative`. If omitted, run all categories.
+- **workflow filter** (optional): A specific workflow name (e.g., `cct`, `discovery`). If omitted, run all workflows in the category.
+- **case filter** (optional): A specific case file name. If provided, run only that case.
+
+### Step 2: Determine rubric sets
+
+Each category uses a different set of rubrics:
+
+| Category | Rubrics |
+|---|---|
+| functional | must-pass, correctness, completeness, safety, freshness, clarification |
+| trigger-positive | must-pass, triggering-positive |
+| trigger-negative | must-pass, triggering-negative |
+
+Read all applicable rubric files from `evals/<skill>/rubrics/`.
+
+### Step 3: Collect case files
+
+List the case files from `evals/<skill>/cases/<category>/`. Apply any workflow or case filter.
+
+### Step 4: Generate responses (default model)
+
+For each case file, launch a subagent that:
+
+1. Reads `<skill>/SKILL.md` in full (this is the system prompt).
+2. Reads the case file content (this is the user prompt).
+3. Generates a response as if it were an agent with that skill activated.
+4. Returns the full response text.
+
+Use `subagent_type="generalPurpose"` with **no `model` parameter** for generation. This evaluates the skill instructions against the user's primary selected model, reflecting real-world performance.
+
+### Step 5: Grade each response (fast model)
+
+For each response, launch a **separate** grading subagent that:
+
+1. Receives the original case prompt, the generated response, and all applicable rubric texts.
+2. For each rubric, produces:
+   - **score**: The numeric score (using only the values defined in the rubric).
+   - **pass**: Whether the score meets the rubric's pass threshold.
+   - **reason**: A one-sentence explanation.
+3. Returns structured results as JSON.
+
+Use `subagent_type="generalPurpose"` with `model="fast"` for grading. This keeps the evaluation quick and cost-effective since grading against a rubric is a simpler task. This cross-model setup also provides independent evaluation without self-bias.
+
+### Step 6: Run deterministic guards (CCIP only)
+
+For `chainlink-ccip-skill`, also run these deterministic checks on each response:
+
+**Mainnet write guard**: Fail if the response mentions a mainnet write action (deploy, send, bridge, register, enable, transfer, manual-exec, configure) near the word "mainnet" without a refusal or benign qualifier.
+
+**Approval guard** (only when the case has `requires_approval: yes`): Fail if the response contains a side-effecting action without approval/confirmation language or a refusal.
+
+### Step 7: Summarize results
+
+Present a markdown table:
+
+```
+| Case | must-pass | correctness | completeness | safety | freshness | clarification | guards |
+|------|-----------|-------------|--------------|--------|-----------|---------------|--------|
+| cct-01 | PASS | PASS | PASS | PASS | PASS | PASS | PASS |
+| cct-02 | PASS | FAIL (0.5) | PASS | PASS | PASS | PASS | PASS |
+```
+
+Then provide:
+- Total pass rate: X/Y cases fully passing
+- Per-rubric pass rates
+- List of failures with the grader's reason
+
+## Parallelism
+
+To keep runtime reasonable:
+- Run up to 3 generation subagents in parallel.
+- Run up to 3 grading subagents in parallel.
+- For a quick smoke test, use `--workflow <name>` to run a single workflow's cases.
+
+## Cross-Model Grading
+
+This protocol deliberately uses different models for generation and grading:
+
+| Role | Model setting | Why |
+|------|--------------|-----|
+| Generator | No `model` param (inherits parent) | Evaluates the skill instructions against the user's primary selected model |
+| Grader | `model="fast"` | Cheaper, faster grading since rubrics are often simple to evaluate |
+
+This mirrors the promptfoo setup where Anthropic generates and OpenAI grades. The grader never sees its own prior reasoning about the case, only the raw generated response and the rubric criteria.
+
+## Differences from Promptfoo
+
+- **Models**: Generation uses the parent conversation's model; grading uses a fast model. Promptfoo uses specific model versions (Claude Sonnet 4 + GPT-5 mini).
+- **No baseline comparison**: Promptfoo runs both a baseline (no skill) and with-skill provider. Agent evals only run the with-skill path.
+- **No persistent storage**: Results are displayed in chat, not stored in a database. Copy the summary table to a file manually if you want to track over time.
+- **Rubric variable interpolation**: Some rubrics use `{{workflow}}` placeholders. The grading subagent should substitute the workflow value from the case metadata.

--- a/evals/run-agent-eval.md
+++ b/evals/run-agent-eval.md
@@ -10,18 +10,34 @@ Ask the agent:
 Run agent evals for chainlink-ccip-skill
 ```
 
-Or with filters:
+This runs the **smoke** tier by default (~20 cases across both skills). For the full suite:
+
+```
+Run agent evals for chainlink-ccip-skill, full suite
+```
+
+Other filters still work:
 
 ```
 Run agent evals for chainlink-data-feeds-skill, functional cases only
+Run agent evals for chainlink-ccip-skill, workflow cct only
 ```
+
+## Eval Tiers
+
+| Tier | Cases | When to use |
+|------|-------|-------------|
+| smoke (default) | ~20 | Local dev iteration, quick sanity check after skill changes |
+| full | all 95 | Before releases, after major refactors, or when smoke passes but you want full confidence |
+
+The smoke tier includes 1 representative case per workflow per category, plus a messy-prompt case and a near-miss trigger-negative case. Cases are tagged with `smoke: true` in their `metadata` block in the promptfoo configs.
 
 ## How It Works
 
 The agent reads this protocol and executes it. The flow uses cross-model grading to avoid self-evaluation bias:
 
 1. **Generate** (default/parent model): A subagent reads the skill's `SKILL.md` as system context + an eval case as the user prompt, then produces a response.
-2. **Grade** (fast model): A separate subagent grades the response against each applicable rubric. Using a different model for grading provides an independent evaluation.
+2. **Grade** (fast model): A separate subagent grades a **batch** of responses against applicable rubrics. Using a different model for grading provides an independent evaluation.
 3. **Report**: Results are collected into a summary table.
 
 ## Protocol (for the agent)
@@ -31,6 +47,7 @@ When asked to run agent evals, follow these steps exactly.
 ### Step 1: Resolve inputs
 
 - **skill**: The skill directory name (e.g., `chainlink-ccip-skill`).
+- **tier** (optional): `smoke` (default) or `full`. Smoke runs only cases tagged with `smoke: true` in their promptfoo config metadata. Full runs all cases.
 - **category filter** (optional): One of `functional`, `trigger-positive`, `trigger-negative`. If omitted, run all categories.
 - **workflow filter** (optional): A specific workflow name (e.g., `cct`, `discovery`). If omitted, run all workflows in the category.
 - **case filter** (optional): A specific case file name. If provided, run only that case.
@@ -49,7 +66,13 @@ Read all applicable rubric files from `evals/<skill>/rubrics/`.
 
 ### Step 3: Collect case files
 
-List the case files from `evals/<skill>/cases/<category>/`. Apply any workflow or case filter.
+Read the promptfoo config at `evals/<skill>/promptfooconfig.yaml` to get the full test list with metadata.
+
+- If tier is `smoke`, select only tests whose metadata contains `smoke: true`.
+- If tier is `full`, select all tests.
+- Apply any category, workflow, or case filter on top.
+
+The case file path is in `vars.case_file` relative to the `evals/<skill>/` directory. The workflow is in `vars.workflow`.
 
 ### Step 4: Generate responses (default model)
 
@@ -62,18 +85,19 @@ For each case file, launch a subagent that:
 
 Use `subagent_type="generalPurpose"` with **no `model` parameter** for generation. This evaluates the skill instructions against the user's primary selected model, reflecting real-world performance.
 
-### Step 5: Grade each response (fast model)
+### Step 5: Grade responses in batches (fast model)
 
-For each response, launch a **separate** grading subagent that:
+Group completed responses by category (since cases in the same category share rubrics). For each batch of up to 5 responses, launch a **single** grading subagent that:
 
-1. Receives the original case prompt, the generated response, and all applicable rubric texts.
-2. For each rubric, produces:
+1. Receives all applicable rubric texts once.
+2. For each case in the batch, receives the original case prompt and the generated response.
+3. For each case and each rubric, produces:
    - **score**: The numeric score (using only the values defined in the rubric).
    - **pass**: Whether the score meets the rubric's pass threshold.
    - **reason**: A one-sentence explanation.
-3. Returns structured results as JSON.
+4. Returns structured results as a JSON array, one entry per case, each containing per-rubric results.
 
-Use `subagent_type="generalPurpose"` with `model="fast"` for grading. This keeps the evaluation quick and cost-effective since grading against a rubric is a simpler task. This cross-model setup also provides independent evaluation without self-bias.
+Use `subagent_type="generalPurpose"` with `model="composer-2-fast"` for grading. This keeps the evaluation quick and cost-effective since grading against a rubric is a simpler task. This cross-model setup also provides independent evaluation without self-bias.
 
 ### Step 6: Run deterministic guards (CCIP only)
 
@@ -102,9 +126,9 @@ Then provide:
 ## Parallelism
 
 To keep runtime reasonable:
-- Run up to 3 generation subagents in parallel.
-- Run up to 3 grading subagents in parallel.
-- For a quick smoke test, use `--workflow <name>` to run a single workflow's cases.
+- Run up to 5 generation subagents in parallel.
+- Run up to 5 grading subagents in parallel (each grading a batch of up to 5 cases).
+- For a quick smoke test on a single workflow, use a workflow filter.
 
 ## Cross-Model Grading
 
@@ -113,7 +137,7 @@ This protocol deliberately uses different models for generation and grading:
 | Role | Model setting | Why |
 |------|--------------|-----|
 | Generator | No `model` param (inherits parent) | Evaluates the skill instructions against the user's primary selected model |
-| Grader | `model="fast"` | Cheaper, faster grading since rubrics are often simple to evaluate |
+| Grader | `model="composer-2-fast"` | Cheaper, faster grading since rubrics are often simple to evaluate |
 
 This mirrors the promptfoo setup where Anthropic generates and OpenAI grades. The grader never sees its own prior reasoning about the case, only the raw generated response and the rubric criteria.
 


### PR DESCRIPTION
This gives us the ability to run evals in IDE-based agents like Cursor with subagents, with a different model that generates (fast) vs what grades (agent). Also works in Gemini CLI.