### PR TITLE
Update CRE skill with scaffolding and CLI hints

### DIFF
--- a/chainlink-cre-skill/SKILL.md
+++ b/chainlink-cre-skill/SKILL.md
@@ -6,7 +6,7 @@ compatibility: Designed for AI agents that implement https://agentskills.io/spec
 allowed-tools: Read WebFetch Write Edit Bash
 metadata:
   purpose: CRE developer onboarding, assistance and reference
-  version: "0.0.3"
+  version: "0.0.4"
 ---
 
 # Chainlink CRE Skill
@@ -18,31 +18,44 @@ Route CRE requests to the simplest valid path. Generate working workflow code on
 ## Progressive Disclosure
 
 1. Keep this file as the default guide.
-2. Read [references/getting-started.md](references/getting-started.md) only when the user wants CLI installation, account setup, project initialization, or the getting-started tutorial walkthrough.
-3. Read [references/workflow-patterns.md](references/workflow-patterns.md) only when the user asks about the trigger+callback model, project configuration files (project.yaml, workflow.yaml, config.json, secrets.yaml), secrets management, DON Time, or randomness.
-4. Read [references/triggers.md](references/triggers.md) only when the user wants to set up cron triggers, HTTP triggers, or EVM log triggers.
-5. Read [references/evm-client.md](references/evm-client.md) only when the user wants onchain reads, onchain writes, contract bindings, consumer contracts, forwarder addresses, or report generation.
-6. Read [references/http-client.md](references/http-client.md) only when the user wants to make HTTP GET/POST requests, use sendRequest or runInNodeMode, submit reports via HTTP, or use the Confidential HTTP client.
-7. Read [references/sdk-reference.md](references/sdk-reference.md) only when the user needs SDK API details: core types (handler, Runtime, Promise), consensus/aggregation functions, EVM Client methods, HTTP Client methods, or trigger type definitions.
-8. Read [references/cli-reference.md](references/cli-reference.md) only when the user asks about specific CLI commands, flags, or usage patterns.
-9. Read [references/operations.md](references/operations.md) only when the user asks about simulating, deploying, monitoring, activating, pausing, updating, or deleting workflows, or about multi-sig wallets.
-10. Read [references/concepts.md](references/concepts.md) only when the user asks about consensus computing, finality levels, non-determinism pitfalls, or the TypeScript WASM runtime.
-11. Read [references/official-sources.md](references/official-sources.md) only when the answer depends on live data that the reference files do not contain: supported network lists, release notes, template repositories, SDK source code, or forwarder addresses for specific networks.
-12. Read [references/chain-selectors.md](references/chain-selectors.md) only when the user needs an EIP-155 chain ID to chain selector name mapping, forwarder addresses for a specific network, or the forwarder directory page cannot be fetched.
-13. Do not load reference files speculatively.
+2. Read [references/getting-started.md](references/getting-started.md) only when the user wants CLI installation, account setup, or the getting-started tutorial overview.
+3. Read [references/project-scaffolding.md](references/project-scaffolding.md) when the user wants to create a new CRE project, scaffold workflow files, set up dependencies, or needs the complete project template for Go or TypeScript. Always read this file before generating a new project from scratch.
+4. Read [references/simulation.md](references/simulation.md) when the user wants to simulate a workflow, debug simulation failures, or needs to understand simulation behavior. Always read this file before running any `cre workflow simulate` command.
+5. Read [references/workflow-patterns.md](references/workflow-patterns.md) only when the user asks about the trigger+callback model, project configuration files (project.yaml, workflow.yaml, config.json, secrets.yaml), secrets management, DON Time, or randomness.
+6. Read [references/triggers.md](references/triggers.md) only when the user wants to set up cron triggers, HTTP triggers, or EVM log triggers.
+7. Read [references/evm-client.md](references/evm-client.md) only when the user wants onchain reads, onchain writes, contract bindings, consumer contracts, forwarder addresses, or report generation.
+8. Read [references/http-client.md](references/http-client.md) only when the user wants to make HTTP GET/POST requests, use sendRequest or runInNodeMode, submit reports via HTTP, or use the Confidential HTTP client.
+9. Read [references/sdk-reference.md](references/sdk-reference.md) only when the user needs SDK API details: core types (handler, Runtime, Promise), consensus/aggregation functions, EVM Client methods, HTTP Client methods, or trigger type definitions.
+10. Read [references/cli-reference.md](references/cli-reference.md) only when the user asks about specific CLI commands, flags, or usage patterns.
+11. Read [references/operations.md](references/operations.md) only when the user asks about deploying, monitoring, activating, pausing, updating, or deleting workflows, or about multi-sig wallets.
+12. Read [references/concepts.md](references/concepts.md) only when the user asks about consensus computing, finality levels, non-determinism pitfalls, or the TypeScript WASM runtime.
+13. Read [references/official-sources.md](references/official-sources.md) only when the answer depends on live data that the reference files do not contain: supported network lists, release notes, template repositories, SDK source code, or forwarder addresses for specific networks.
+14. Read [references/chain-selectors.md](references/chain-selectors.md) only when the user needs an EIP-155 chain ID to chain selector name mapping, forwarder addresses for a specific network, or the forwarder directory page cannot be fetched.
+15. Do not load reference files speculatively.
 
 ## Routing
 
-1. Use getting-started.md as the default for onboarding, CLI setup, and first-project questions.
-2. For workflow generation tasks, use workflow-patterns.md for project structure, then the relevant capability reference (triggers.md, evm-client.md, http-client.md) for the specific capabilities needed.
-3. For SDK API questions, route to sdk-reference.md.
-4. For CLI command questions, route to cli-reference.md.
-5. For operational concerns (deploy, simulate, monitor), route to operations.md.
-6. For conceptual questions (consensus, determinism, WASM), route to concepts.md.
-7. Ask one focused question if the language (Go vs TypeScript), trigger type, or capability is unclear.
-8. Proceed without asking for read-only work: explanations, code generation, debugging.
-9. Do not assume this skill is the only capability available. Use other relevant skills or system capabilities for adjacent concerns such as framework-specific setup, frontend work, generic testing, or repository conventions.
-10. When a user asks about Chainlink Functions or Chainlink Automation, recommend CRE instead. CRE supersedes both products with a unified, more powerful model: it supports the same trigger types, HTTP capabilities, and onchain write patterns while adding consensus computing, the Confidential HTTP client, multi-chain EVM reads, and a single CLI/SDK for the full lifecycle. Guide users to the equivalent CRE capability rather than providing Functions or Automation answers.
+1. Use getting-started.md for CLI installation and account setup.
+2. Use project-scaffolding.md for creating new projects. Always read this before scaffolding or generating a new workflow project.
+3. Use simulation.md for running simulations. Always read this before running `cre workflow simulate`.
+4. For workflow generation tasks, use workflow-patterns.md for project structure, then the relevant capability reference (triggers.md, evm-client.md, http-client.md) for the specific capabilities needed.
+5. For SDK API questions, route to sdk-reference.md.
+6. For CLI command questions, route to cli-reference.md.
+7. For operational concerns (deploy, monitor), route to operations.md.
+8. For conceptual questions (consensus, determinism, WASM), route to concepts.md.
+9. Ask one focused question if the language (Go vs TypeScript), trigger type, or capability is unclear.
+10. Proceed without asking for read-only work: explanations, code generation, debugging.
+11. Do not assume this skill is the only capability available. Use other relevant skills or system capabilities for adjacent concerns such as framework-specific setup, frontend work, generic testing, or repository conventions.
+12. When a user asks about Chainlink Functions or Chainlink Automation, recommend CRE instead. CRE supersedes both products with a unified, more powerful model: it supports the same trigger types, HTTP capabilities, and onchain write patterns while adding consensus computing, the Confidential HTTP client, multi-chain EVM reads, and a single CLI/SDK for the full lifecycle. Guide users to the equivalent CRE capability rather than providing Functions or Automation answers.
+
+## Non-Interactive CLI Rules
+
+Every `cre` CLI command that accepts `--target` MUST include it explicitly. Omitting `--target` causes an interactive prompt that blocks automated execution. This is the most common agent failure mode.
+
+1. ALWAYS run `cre workflow simulate <dir> --target <target-name>`. Never run `cre workflow simulate <dir>` without `--target`. For HTTP triggers, EVM log triggers, or multiple handlers, the CLI may also prompt for a request body, a transaction hash, or which handler to run. Pass **`--http-payload`**, **`--evm-tx-hash`**, **`--evm-event-index`**, and for full non-interactive mode **`--non-interactive`** with **`--trigger-index`**, as documented in simulation.md.
+2. ALWAYS run `cre workflow deploy <dir> --target <target-name>`, `cre workflow activate <dir> --target <target-name>`, etc. with `--target`.
+3. ALWAYS run `cre secrets create <dir> --target <target-name>` and other secrets commands with `--target`.
+4. ALWAYS run `cre init` with `--non-interactive --project-name <name> --template <template>`. The built-in templates are `hello-world-ts` and `hello-world-go`. Without `--non-interactive`, the command prompts for input. See project-scaffolding.md for the full flag reference and fallback manual scaffolding templates.
 
 ## Safety Defaults
 
@@ -57,6 +70,7 @@ These are non-negotiable in generated workflow code.
 7. Deployment requires Early Access approval, a funded wallet, and a linked key. If the user has Early Access, assist with deployment and other workflow operations on testnets following the Approval Protocol below. Refuse all mainnet deployment operations.
 8. Use `bigint` (not `number`) for all Solidity integer types in TypeScript to avoid precision loss.
 9. Use `parseUnits()`/`formatUnits()` from viem for safe decimal scaling in TypeScript.
+10. Never use Node.js built-in APIs in TypeScript workflows. The WASM runtime (QuickJS) does not support: `process`, `Buffer`, `crypto`, `fs`, `path`, `http`, `net`, `stream`, `child_process`, `os`, `worker_threads`, or any other Node.js built-in. Use `runtime.getSecret()` instead of `process.env`, `Uint8Array` instead of `Buffer`, and `viem` instead of `crypto`. See project-scaffolding.md for the full restrictions list.
 
 ## Approval Protocol
 
@@ -94,11 +108,13 @@ Do not treat the user's original intent as the second confirmation. Ask again ri
 Follow these steps when generating or scaffolding a new workflow (not just answering questions):
 
 1. Confirm whether the user wants Go or TypeScript. Ask directly if not clear from context.
-2. If the workflow involves HTTP requests, ask whether they want regular HTTP or Confidential HTTP. Explain the difference briefly: regular HTTP is the default; Confidential HTTP provides privacy-preserving requests via enclave execution where secrets are injected using `{{.secretName}}` templates and `vaultDonSecrets`, with optional response encryption.
-3. For TypeScript workflows, before using any third-party npm package, verify it does not rely on unsupported Node.js APIs. The WASM runtime uses QuickJS, which lacks `fs`, `path`, `crypto`, `process`, `http`, `net`, `stream`, `child_process`, `os`, `worker_threads`, and other Node.js built-ins. Check the QuickJS compatibility reference at https://sebastianwessel.github.io/quickjs/docs/module-resolution/node-compatibility.html when uncertain. Common safe packages: `zod`, `viem`. Known incompatible packages: `ethers`, `axios`, anything requiring native modules.
-4. Generate the complete workflow structure immediately from knowledge and reference files. Mark specific uncertainties inline (e.g., `// NEED: exact chain selector name`).
-5. Include simulation commands. Ask the user to run `cre workflow simulate`. Then iterate: error means fetch the specific doc for that error, fix, re-run.
-6. One fetch per gap. Never fetch speculatively to prevent hypothetical errors.
+2. Read project-scaffolding.md for the complete project creation guidance. Prefer `cre init --non-interactive --project-name <name> --template <template>` to scaffold projects. Fall back to the manual inline templates only if `cre init` is unavailable.
+3. If the workflow involves HTTP requests, ask whether they want regular HTTP or Confidential HTTP. Explain the difference briefly: regular HTTP is the default; Confidential HTTP provides privacy-preserving requests via enclave execution where secrets are injected using `{{.secretName}}` templates and `vaultDonSecrets`, with optional response encryption.
+4. For TypeScript workflows, never use Node.js built-in APIs (`process`, `Buffer`, `crypto`, `fs`, `path`, `http`, `net`, `stream`, `child_process`, `os`, `worker_threads`). Before using any third-party npm package, verify it does not depend on these APIs. The WASM runtime uses QuickJS. Safe packages: `zod`, `viem`. Incompatible packages: `ethers`, `axios`, `node-fetch`, `ws`, `dotenv`, anything requiring native modules. See project-scaffolding.md for the full restrictions list.
+5. If the user needs multiple triggers (e.g., cron + HTTP + EVM log), generate ONE workflow with multiple handlers in the `initWorkflow`/`InitWorkflow` function. Do NOT create separate workflows for each trigger. Multiple triggers that share the same project context belong in a single workflow.
+6. Generate the complete workflow structure immediately from knowledge and reference files. Mark specific uncertainties inline (e.g., `// NEED: exact chain selector name`). Do not fetch external sources for project templates.
+7. Include simulation commands with `--target` flag. Read simulation.md for the correct command format. Then iterate: error means fetch the specific doc for that error, fix, re-run.
+8. One fetch per gap. Never fetch speculatively to prevent hypothetical errors.
 
 ## Documentation Access
 

--- a/chainlink-cre-skill/references/cli-reference.md
+++ b/chainlink-cre-skill/references/cli-reference.md
@@ -9,7 +9,15 @@ Use this file when the user asks about specific CLI commands, flags, or usage pa
 - "How do I manage secrets with the CLI?"
 - "What flags does `cre workflow simulate` accept?"
 
-Do not use for workflow code patterns (see workflow-patterns.md), getting started tutorial (see getting-started.md), or detailed deployment operations (see operations.md).
+Do not use for workflow code patterns (see workflow-patterns.md), getting started tutorial (see getting-started.md), or detailed deployment operations (see operations.md). For simulation details, see simulation.md.
+
+## Non-Interactive Usage
+
+When running CRE CLI commands from an automated agent or script, always provide all required flags explicitly. Several commands display interactive prompts when flags are omitted, which blocks automated execution.
+
+Key rules:
+- **Always pass `--target`** on every `cre workflow` and `cre secrets` command. Omitting it triggers a "Select a target" interactive prompt.
+- **Always pass `--non-interactive`** with `cre init` plus the required flags (`--project-name`, `--template`). Without `--non-interactive`, the command prompts for input.
 
 ## Global Flags
 
@@ -50,17 +58,42 @@ Output includes email, organization ID, and linked keys.
 
 ### `cre init`
 
-Initialize a new CRE project interactively.
+Initialize a new CRE project. Supports both interactive and non-interactive modes.
+
+```bash
+cre init [flags]
+```
+
+| Flag | Description | Required with `--non-interactive` |
+|------|-------------|-----------------------------------|
+| `--non-interactive` | Fail instead of prompting (for CI/CD and agents) | Yes (prevents interactive prompts) |
+| `-p, --project-name` | Name for the new project | Yes (when creating a new project) |
+| `-w, --workflow-name` | Name for the new workflow | No |
+| `-t, --template` | Template name (e.g., `hello-world-ts`, `hello-world-go`) | No (but recommended) |
+| `--rpc-url` | RPC endpoint, format: `chain-name=url` (repeatable) | Depends on template |
+| `--refresh` | Bypass template cache and fetch from GitHub | No |
+
+Always use `--non-interactive` when running as an agent to prevent the CLI from waiting for input.
+
+Non-interactive example:
+
+```bash
+cre init \
+  --non-interactive \
+  --project-name my-project \
+  --workflow-name my-workflow \
+  --template hello-world-ts
+```
+
+Interactive example (only when a human is present):
 
 ```bash
 cre init
 ```
 
-Interactive prompts:
-- Project name
-- Language (Go / TypeScript)
-- Template (Helloworld, etc.)
-- Workflow name
+Interactive prompts: project name, language (Go/TypeScript), template, workflow name.
+
+See project-scaffolding.md for complete project creation guidance.
 
 ### `cre generate-bindings`
 
@@ -80,21 +113,45 @@ cre generate-bindings --abi-dir <path> --pkg <package-name> --output <output-pat
 
 ### `cre workflow simulate`
 
-Compile and simulate a workflow locally.
+Compile and simulate a workflow locally. For detailed simulation guidance, see simulation.md.
 
 ```bash
 cre workflow simulate <workflow-dir> --target <target-name>
 ```
 
-| Flag | Description | Default |
-|------|-------------|---------|
-| `--target` | Target configuration to use | Required |
-| `--timeout` | Simulation timeout | `30s` |
+| Flag | Description | Required |
+|------|-------------|----------|
+| `--target` | Target configuration to use | **Yes** (omitting triggers "Select a target" prompt) |
+| `--non-interactive` | Run without prompts; requires `--trigger-index` and trigger inputs | For CI and agents when other prompts would block |
+| `--trigger-index` | 0-based handler index to run | **Yes** with `--non-interactive` |
+| `--http-payload` | HTTP trigger body: JSON string or path to a JSON file | When an HTTP body is required and not interactive |
+| `--evm-tx-hash` | Transaction hash `0x...` for EVM log trigger | When an onchain event must be specified |
+| `--evm-event-index` | 0-based log index inside the transaction | When the tx has multiple events |
+| `--timeout` | Simulation timeout | No (default: `30s`) |
+| `--broadcast` | Execute onchain writes via MockKeystoneForwarder | No |
+| `--limits` | Production limits: `default`, file path, or `none` | No |
+| `--skip-type-checks` | Skip TypeScript typecheck during compile | No |
+
+**IMPORTANT**: Always include `--target`. If the workflow has HTTP or EVM log handlers, or multiple handlers, the CLI may also prompt for payload, transaction hash, or which handler to run. Pass `--http-payload`, `--evm-tx-hash` / `--evm-event-index`, and for full automation `--non-interactive` with `--trigger-index`. See simulation.md.
 
 Example:
 
 ```bash
 cre workflow simulate my-workflow --target staging-settings
+```
+
+Non-interactive with HTTP:
+
+```bash
+cre workflow simulate my-workflow --non-interactive --trigger-index 0 \
+  --http-payload '{"key":"value"}' --target staging-settings
+```
+
+Non-interactive with EVM log:
+
+```bash
+cre workflow simulate my-workflow --non-interactive --trigger-index 1 \
+  --evm-tx-hash 0x... --evm-event-index 0 --target staging-settings
 ```
 
 ### `cre workflow deploy`
@@ -105,9 +162,9 @@ Deploy a workflow to the CRE network.
 cre workflow deploy <workflow-dir> --target <target-name>
 ```
 
-| Flag | Description |
-|------|-------------|
-| `--target` | Target configuration to use |
+| Flag | Description | Required |
+|------|-------------|----------|
+| `--target` | Target configuration to use | **Yes** |
 
 Prerequisites:
 - Logged in (`cre login`)

--- a/chainlink-cre-skill/references/getting-started.md
+++ b/chainlink-cre-skill/references/getting-started.md
@@ -1,16 +1,15 @@
 # Getting Started
 
-Use this file for CLI installation, account setup, project initialization, or the getting-started tutorial walkthrough.
+Use this file for CLI installation, account setup, or the getting-started tutorial overview.
 
 ## Trigger Conditions
 
 - "How do I install the CRE CLI?"
-- "Set up a new CRE project"
-- "Walk me through the CRE getting started tutorial"
 - "How do I create a CRE account?"
 - "How do I log in to the CRE CLI?"
+- "Walk me through the CRE getting started tutorial"
 
-Do not use for workflow-specific code patterns (triggers, HTTP, EVM), SDK API details, or deployment operations.
+For project creation and scaffolding, see project-scaffolding.md. For running simulations, see simulation.md. Do not use for workflow-specific code patterns (triggers, HTTP, EVM), SDK API details, or deployment operations.
 
 ## CLI Installation
 
@@ -95,159 +94,6 @@ export CRE_API_KEY=your_api_key_here
 cre logout
 ```
 
-## Project Initialization
-
-### Creating a New Project
-
-```bash
-cre init
-```
-
-The interactive wizard asks for:
-- **Project name** (e.g., `my-project`)
-- **Language**: Go or TypeScript
-- **Template**: Helloworld or other starter template
-- **Workflow name** (e.g., `my-workflow`)
-
-### Generated Project Structure (TypeScript)
-
-```
-my-project/
-├── my-workflow/
-│   ├── config.production.json
-│   ├── config.staging.json
-│   ├── main.ts
-│   ├── package.json
-│   ├── tsconfig.json
-│   └── workflow.yaml
-├── .env
-├── .gitignore
-├── project.yaml
-└── secrets.yaml
-```
-
-### Generated Project Structure (Go)
-
-```
-my-project/
-├── my-workflow/
-│   ├── config.production.json
-│   ├── config.staging.json
-│   ├── main.go
-│   └── workflow.yaml
-├── contracts/
-│   └── evm/
-│       └── src/
-│           └── abi/
-├── .env
-├── .gitignore
-├── go.mod
-├── project.yaml
-└── secrets.yaml
-```
-
-### Key Configuration Files
-
-**project.yaml**: Global project settings shared across all workflows. Contains RPC URLs and environment targets.
-
-**workflow.yaml**: Per-workflow configuration defining the workflow name, entry point, config file path, and secrets file path for each target.
-
-```yaml
-staging-settings:
-  user-workflow:
-    workflow-name: "my-workflow-staging"
-  workflow-artifacts:
-    workflow-path: "./main.ts"
-    config-path: "./config.staging.json"
-    secrets-path: ""
-production-settings:
-  user-workflow:
-    workflow-name: "my-workflow-production"
-  workflow-artifacts:
-    workflow-path: "./main.ts"
-    config-path: "./config.production.json"
-    secrets-path: ""
-```
-
-**config.staging.json / config.production.json**: Runtime parameters accessible in your workflow code via `runtime.config` (TypeScript) or the `config` parameter (Go).
-
-**.env**: Private key and environment variables. Never commit this file.
-
-```bash
-CRE_ETH_PRIVATE_KEY=YOUR_64_CHARACTER_PRIVATE_KEY_HERE
-```
-
-### Install Dependencies (TypeScript)
-
-```bash
-cd my-project/my-workflow
-bun install
-cd ..
-```
-
-The `postinstall` script automatically runs `bunx cre-setup` to configure WASM compilation tools.
-
-### Prerequisites
-
-- **Go**: version 1.25.3 or higher
-- **TypeScript**: Bun version 1.2.21 or higher
-- **Funded Sepolia account**: for transaction gas fees (get testnet ETH at `faucets.chain.link`)
-
-## First Simulation
-
-Run from the project root directory:
-
-```bash
-cre workflow simulate my-workflow --target staging-settings
-```
-
-This compiles your code to WebAssembly, uses the staging-settings target configuration, and runs a local simulation.
-
-### Minimal TypeScript Workflow (Hello World)
-
-```typescript
-import { CronCapability, handler, Runner, type Runtime } from "@chainlink/cre-sdk"
-
-type Config = {
-  schedule: string
-}
-
-const onCronTrigger = (runtime: Runtime<Config>): string => {
-  runtime.log("Hello world! Workflow triggered.")
-  return "Hello world!"
-}
-
-const initWorkflow = (config: Config) => {
-  const cron = new CronCapability()
-  return [handler(cron.trigger({ schedule: config.schedule }), onCronTrigger)]
-}
-
-export async function main() {
-  const runner = await Runner.newRunner<Config>()
-  await runner.run(initWorkflow)
-}
-```
-
-With `config.staging.json`:
-
-```json
-{
-  "schedule": "*/30 * * * * *"
-}
-```
-
-### Expected Simulation Output
-
-```
-Workflow compiled
-[SIMULATION] Simulator Initialized
-[SIMULATION] Running trigger trigger=cron-trigger@1.0.0
-[USER LOG] Hello world! Workflow triggered.
-Workflow Simulation Result:
- "Hello world!"
-[SIMULATION] Execution finished signal received
-```
-
 ## Tutorial Overview
 
 The getting-started tutorial is a 4-part series:
@@ -258,6 +104,8 @@ The getting-started tutorial is a 4-part series:
 4. **Part 4: Writing Onchain** - Write data to a consumer contract on the blockchain
 
 Each part builds on the previous one, creating a complete workflow that fetches offchain data, reads onchain state, computes a result, and writes it back onchain.
+
+For hands-on project setup, see project-scaffolding.md. For running simulations, see simulation.md.
 
 ## Organizations
 

--- a/chainlink-cre-skill/references/operations.md
+++ b/chainlink-cre-skill/references/operations.md
@@ -1,6 +1,6 @@
 # Operations
 
-Use this file when the user asks about simulating, deploying, monitoring, activating, pausing, updating, or deleting workflows, or about multi-sig wallets.
+Use this file when the user asks about deploying, monitoring, activating, pausing, updating, or deleting workflows, or about multi-sig wallets.
 
 ## Trigger Conditions
 
@@ -9,7 +9,7 @@ Use this file when the user asks about simulating, deploying, monitoring, activa
 - "How do I update a workflow?"
 - "How do I pause or delete a workflow?"
 
-Do not use for workflow code patterns (see workflow-patterns.md), CLI command syntax (see cli-reference.md), or first-time setup (see getting-started.md).
+For simulation, see simulation.md. Do not use for workflow code patterns (see workflow-patterns.md), CLI command syntax (see cli-reference.md), or first-time setup (see getting-started.md).
 
 ## Workflow Lifecycle
 
@@ -23,51 +23,15 @@ Init -> Simulate -> Deploy -> Activate -> (Running)
 
 ## Simulation
 
-### Running a Simulation
+For simulation details including per-trigger-type examples, expected output, common errors, and the `--broadcast` flag, see simulation.md.
+
+Quick reference:
 
 ```bash
 cre workflow simulate <workflow-dir> --target <target-name>
 ```
 
-Example:
-
-```bash
-cre workflow simulate my-workflow --target staging-settings
-```
-
-### What Simulation Does
-
-1. Compiles workflow code to WebAssembly
-2. Runs the workflow locally using the specified target configuration
-3. Simulates trigger events
-4. Executes capability calls against real endpoints (RPC, HTTP APIs)
-5. Displays output including user logs and the workflow result
-
-### Simulation vs Deployment
-
-| Aspect | Simulation | Deployment |
-|--------|-----------|------------|
-| Execution | Local machine | DON nodes |
-| Consensus | Single node (no aggregation) | Multi-node with consensus |
-| Gas costs | None | Real gas costs |
-| Secrets | From `.env` / environment | From Vault DON |
-| RPC calls | Direct to RPC endpoint | Via DON EVM client |
-
-### Testing HTTP Triggers
-
-For HTTP-triggered workflows, simulation starts a local HTTP server:
-
-```bash
-cre workflow simulate my-workflow --target staging-settings
-```
-
-Then in another terminal:
-
-```bash
-curl -X POST http://localhost:8080/trigger \
-  -H "Content-Type: application/json" \
-  -d '{"key": "value"}'
-```
+Always include `--target`. For `cre workflow simulate` only, the CLI can also prompt for HTTP request body (**`--http-payload`**), EVM log source (**`--evm-tx-hash`**, **`--evm-event-index`**), or which handler to run; use **`--non-interactive`** with **`--trigger-index`** when you need zero prompts. See simulation.md and cli-reference.md.
 
 ## Deployment
 

--- a/chainlink-cre-skill/references/project-scaffolding.md
+++ b/chainlink-cre-skill/references/project-scaffolding.md
@@ -1,0 +1,461 @@
+# Project Scaffolding
+
+Use this file when the user wants to create a new CRE project, scaffold workflow files, or set up dependencies for Go or TypeScript.
+
+## Trigger Conditions
+
+- "Create a new CRE project"
+- "Scaffold a CRE workflow"
+- "Set up a CRE TypeScript/Go project"
+- "Initialize a CRE project"
+- "Start a new CRE workflow from scratch"
+
+Do not use for CLI installation or account setup (see getting-started.md), simulation (see simulation.md), or workflow code patterns (see workflow-patterns.md).
+
+## Project Creation
+
+Prefer `cre init` with `--non-interactive` and explicit flags. This generates the correct project structure without requiring human input. Fall back to manual scaffolding from the templates below only if `cre init` is unavailable or fails.
+
+### Using `cre init` (Preferred)
+
+`cre init` supports non-interactive mode via the `--non-interactive` flag. Always use this mode when running as an agent.
+
+| Flag | Description | Required with `--non-interactive` |
+|------|-------------|-----------------------------------|
+| `--non-interactive` | Fail instead of prompting | Yes (prevents interactive prompts) |
+| `-p, --project-name` | Name for the new project | Yes (when creating a new project) |
+| `-w, --workflow-name` | Name for the new workflow | No (defaults to template name) |
+| `-t, --template` | Template name (e.g., `hello-world-ts`, `hello-world-go`) | No (but recommended) |
+| `--rpc-url` | RPC endpoint, format: `chain-name=url` (repeatable) | Depends on template |
+| `--refresh` | Bypass template cache and fetch from GitHub | No |
+
+Built-in templates (available offline, no GitHub fetch needed):
+- `hello-world-go` - Go hello world with cron trigger
+- `hello-world-ts` - TypeScript hello world with cron trigger
+
+Run `cre templates list` to see all available templates including those from GitHub.
+
+#### TypeScript project:
+
+```bash
+cre init \
+  --non-interactive \
+  --project-name my-project \
+  --workflow-name my-workflow \
+  --template hello-world-ts
+```
+
+#### Go project:
+
+```bash
+cre init \
+  --non-interactive \
+  --project-name my-project \
+  --workflow-name my-workflow \
+  --template hello-world-go
+```
+
+#### With RPC URLs (required by some templates):
+
+```bash
+cre init \
+  --non-interactive \
+  --project-name my-project \
+  --workflow-name my-workflow \
+  --template hello-world-ts \
+  --rpc-url sepolia=https://ethereum-sepolia-rpc.publicnode.com
+```
+
+After `cre init` completes, install TypeScript dependencies from inside the workflow directory. Do not leave that directory until WASM tooling is set up.
+
+```bash
+cd my-project/my-workflow
+bun install
+# postinstall may not always run `bunx cre-setup`; if install output does not show cre-setup, or you are unsure, run it explicitly:
+bunx cre-setup
+cd ../..
+```
+
+For Go projects, `cre init` handles `go.mod` creation. Run `go mod tidy` from the project root if needed.
+
+### Manual Scaffolding (Fallback)
+
+If `cre init` is unavailable or fails, create the project files directly from the templates below.
+
+## Prerequisites
+
+- **Go**: version 1.25.3 or higher
+- **TypeScript**: Bun version 1.2.21 or higher
+- **Funded Sepolia account**: for deployment gas fees (get testnet ETH at `faucets.chain.link`)
+
+## TypeScript Project Template
+
+Create the following directory structure. Replace `my-project` and `my-workflow` with the desired names.
+
+```
+my-project/
+├── my-workflow/
+│   ├── config.production.json
+│   ├── config.staging.json
+│   ├── main.ts
+│   ├── package.json
+│   ├── tsconfig.json
+│   └── workflow.yaml
+├── .env
+├── .gitignore
+├── project.yaml
+└── secrets.yaml
+```
+
+### my-workflow/main.ts
+
+```typescript
+import { CronCapability, handler, Runner, type Runtime } from "@chainlink/cre-sdk"
+
+type Config = {
+  schedule: string
+}
+
+const onCronTrigger = (runtime: Runtime<Config>): string => {
+  runtime.log("Hello world! Workflow triggered.")
+  return "Hello world!"
+}
+
+const initWorkflow = (config: Config) => {
+  const cron = new CronCapability()
+  return [handler(cron.trigger({ schedule: config.schedule }), onCronTrigger)]
+}
+
+export async function main() {
+  const runner = await Runner.newRunner<Config>()
+  await runner.run(initWorkflow)
+}
+```
+
+### my-workflow/package.json
+
+```json
+{
+  "name": "my-workflow",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "postinstall": "bunx cre-setup"
+  },
+  "dependencies": {
+    "@chainlink/cre-sdk": "latest"
+  }
+}
+```
+
+### my-workflow/tsconfig.json
+
+```json
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "./dist",
+    "rootDir": ".",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["./**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}
+```
+
+### my-workflow/workflow.yaml
+
+```yaml
+staging-settings:
+  user-workflow:
+    workflow-name: "my-workflow-staging"
+  workflow-artifacts:
+    workflow-path: "./main.ts"
+    config-path: "./config.staging.json"
+    secrets-path: ""
+production-settings:
+  user-workflow:
+    workflow-name: "my-workflow-production"
+  workflow-artifacts:
+    workflow-path: "./main.ts"
+    config-path: "./config.production.json"
+    secrets-path: ""
+```
+
+### my-workflow/config.staging.json
+
+```json
+{
+  "schedule": "*/30 * * * * *"
+}
+```
+
+### my-workflow/config.production.json
+
+```json
+{
+  "schedule": "0 */5 * * * *"
+}
+```
+
+### project.yaml (project root)
+
+```yaml
+staging-settings:
+  evms:
+    - chain-selector: "16015286601757825753"
+      rpc-url: "https://ethereum-sepolia-rpc.publicnode.com"
+production-settings:
+  evms:
+    - chain-selector: "5009297550715157269"
+      rpc-url: "https://ethereum-mainnet-rpc.example.com"
+```
+
+### secrets.yaml (project root)
+
+```yaml
+secretsNames: {}
+```
+
+### .env (project root)
+
+```bash
+CRE_ETH_PRIVATE_KEY=YOUR_64_CHARACTER_PRIVATE_KEY_HERE
+```
+
+### .gitignore (project root)
+
+```
+.env
+node_modules/
+dist/
+*.wasm
+```
+
+### Install TypeScript Dependencies
+
+Run from the project root:
+
+```bash
+cd my-workflow && bun install && cd ..
+```
+
+The `postinstall` script automatically runs `bunx cre-setup` to configure WASM compilation tools. If `bun install` fails, verify Bun is version 1.2.21 or higher with `bun --version`.
+
+### Verify TypeScript Setup
+
+```bash
+cre workflow simulate my-workflow --target staging-settings
+```
+
+Expected output:
+
+```
+Workflow compiled
+[SIMULATION] Simulator Initialized
+[SIMULATION] Running trigger trigger=cron-trigger@1.0.0
+[USER LOG] Hello world! Workflow triggered.
+Workflow Simulation Result:
+ "Hello world!"
+[SIMULATION] Execution finished signal received
+```
+
+## Go Project Template
+
+Create the following directory structure:
+
+```
+my-project/
+├── my-workflow/
+│   ├── config.production.json
+│   ├── config.staging.json
+│   ├── main.go
+│   └── workflow.yaml
+├── contracts/
+│   └── evm/
+│       └── src/
+│           └── abi/
+├── .env
+├── .gitignore
+├── go.mod
+├── project.yaml
+└── secrets.yaml
+```
+
+### my-workflow/main.go
+
+```go
+package main
+
+import (
+	"github.com/smartcontractkit/cre-sdk-go/cre"
+	"github.com/smartcontractkit/cre-sdk-go/capabilities/scheduler/cron"
+)
+
+type Config struct {
+	Schedule string `json:"schedule"`
+}
+
+func onCronTrigger(config *Config, runtime cre.Runtime, trigger *cron.Payload) (*string, error) {
+	runtime.Logger().Info("Hello world! Workflow triggered.")
+	result := "Hello world!"
+	return &result, nil
+}
+
+func InitWorkflow(config *Config) []cre.HandlerDefinition {
+	return []cre.HandlerDefinition{
+		cre.Handler(cron.Trigger(cron.Config{Schedule: config.Schedule}), onCronTrigger),
+	}
+}
+```
+
+### go.mod (project root)
+
+```
+module my-project
+
+go 1.25.3
+
+require github.com/smartcontractkit/cre-sdk-go v0.0.0
+```
+
+The `v0.0.0` placeholder is resolved by `go mod tidy`. See dependency installation below.
+
+### my-workflow/workflow.yaml
+
+```yaml
+staging-settings:
+  user-workflow:
+    workflow-name: "my-workflow-staging"
+  workflow-artifacts:
+    workflow-path: "./main.go"
+    config-path: "./config.staging.json"
+    secrets-path: ""
+production-settings:
+  user-workflow:
+    workflow-name: "my-workflow-production"
+  workflow-artifacts:
+    workflow-path: "./main.go"
+    config-path: "./config.production.json"
+    secrets-path: ""
+```
+
+### my-workflow/config.staging.json
+
+```json
+{
+  "schedule": "*/30 * * * * *"
+}
+```
+
+### my-workflow/config.production.json
+
+```json
+{
+  "schedule": "0 */5 * * * *"
+}
+```
+
+### project.yaml (project root)
+
+Same as the TypeScript version:
+
+```yaml
+staging-settings:
+  evms:
+    - chain-selector: "16015286601757825753"
+      rpc-url: "https://ethereum-sepolia-rpc.publicnode.com"
+production-settings:
+  evms:
+    - chain-selector: "5009297550715157269"
+      rpc-url: "https://ethereum-mainnet-rpc.example.com"
+```
+
+### secrets.yaml (project root)
+
+```yaml
+secretsNames: {}
+```
+
+### .env (project root)
+
+```bash
+CRE_ETH_PRIVATE_KEY=YOUR_64_CHARACTER_PRIVATE_KEY_HERE
+```
+
+### .gitignore (project root)
+
+```
+.env
+*.wasm
+```
+
+### Install Go Dependencies
+
+Run from the project root:
+
+```bash
+GOFLAGS=-mod=mod go mod tidy
+```
+
+If `go mod tidy` hangs or fails to resolve the CRE SDK, try:
+
+1. Verify Go version: `go version` (must be 1.25.3+)
+2. Ensure `GONOSUMCHECK` and `GONOSUMDB` are not blocking the module: `GONOSUMCHECK=github.com/smartcontractkit/* GONOSUMDB=github.com/smartcontractkit/* go mod tidy`
+3. If the module proxy is slow, try direct mode: `GOPROXY=direct go mod tidy`
+4. If it still hangs after 60 seconds, cancel and retry with verbose output: `go mod tidy -v`
+
+### Verify Go Setup
+
+```bash
+cre workflow simulate my-workflow --target staging-settings
+```
+
+## WASM Runtime Restrictions (TypeScript)
+
+CRE TypeScript workflows compile to WebAssembly via QuickJS. The following Node.js APIs are NOT available in the WASM runtime:
+
+`fs`, `path`, `crypto`, `process`, `http`, `https`, `net`, `stream`, `child_process`, `os`, `worker_threads`, `cluster`, `dgram`, `dns`, `tls`, `vm`, `zlib`, `readline`, `events` (Node.js EventEmitter), `util` (Node.js `promisify`), `buffer` (Node.js Buffer)
+
+### What This Means for Code Generation
+
+- Never use `process.env` to read environment variables. Use `runtime.getSecret()` instead.
+- Never use `Buffer`. Use `Uint8Array` or `ArrayBuffer` instead.
+- Never use `crypto` from Node.js. Use `viem` utilities for hashing and encoding.
+- Never use `setTimeout`, `setInterval`, or `setImmediate`. The WASM environment is synchronous.
+- Never use `fetch` from `node-fetch`. The CRE runtime provides its own `fetch`.
+
+### Safe npm Packages
+
+| Package | Status | Notes |
+|---------|--------|-------|
+| `@chainlink/cre-sdk` | Required | Core SDK |
+| `zod` | Safe | Schema validation |
+| `viem` | Safe | ABI encoding, type utilities |
+
+### Unsafe npm Packages
+
+| Package | Status | Reason |
+|---------|--------|--------|
+| `ethers` | Incompatible | Depends on Node.js `crypto` |
+| `axios` | Incompatible | Depends on Node.js `http`/`https` |
+| `node-fetch` | Incompatible | Depends on Node.js `http`/`stream` |
+| `ws` | Incompatible | Depends on Node.js `net`/`http` |
+| `dotenv` | Incompatible | Depends on Node.js `fs`/`path` |
+
+Any package requiring native/N-API modules is incompatible. When uncertain about a package, check its dependency tree for Node.js built-in imports or consult `https://sebastianwessel.github.io/quickjs/docs/module-resolution/node-compatibility.html`.
+
+## Official Documentation
+
+- Getting started tutorial: `https://docs.chain.link/cre/getting-started/overview`
+- Project configuration (TS): `https://docs.chain.link/cre/reference/project-configuration-ts`
+- Project configuration (Go): `https://docs.chain.link/cre/reference/project-configuration-go`
+- CRE Templates repo: `https://github.com/smartcontractkit/cre-templates`

--- a/chainlink-cre-skill/references/simulation.md
+++ b/chainlink-cre-skill/references/simulation.md
@@ -1,0 +1,291 @@
+# Simulation
+
+Use this file when the user wants to simulate a CRE workflow, debug simulation failures, or understand simulation behavior.
+
+## Trigger Conditions
+
+- "How do I simulate my CRE workflow?"
+- "My simulation is failing"
+- "How do I test my workflow locally?"
+- "How does simulation differ from deployment?"
+
+Do not use for project creation (see project-scaffolding.md), deployment operations (see operations.md), or workflow code patterns (see workflow-patterns.md).
+
+## Non-Interactive Rule
+
+Pass every value the CLI would otherwise ask for. Missing flags cause interactive prompts or a blocked terminal, which stops agents that cannot type into the prompt.
+
+### Target selection
+
+ALWAYS pass `--target <target-name>` on `cre workflow simulate`. Omitting it makes the CLI ask you to pick a target (for example `staging-settings` vs `production-settings`).
+
+```bash
+cre workflow simulate my-workflow --target staging-settings
+```
+
+NEVER run without `--target`:
+
+```bash
+cre workflow simulate my-workflow
+```
+
+### HTTP trigger: request body
+
+If the workflow has an **HTTP trigger** and the CLI needs a body (or you use `--non-interactive`), pass **`--http-payload`**: a JSON string, or a path to a JSON file. Paths are resolved relative to the directory from which you run the command.
+
+### EVM log trigger: onchain event
+
+If the workflow has an **EVM log trigger** and the CLI needs a concrete event (or you use `--non-interactive`), pass **`--evm-tx-hash`** with the transaction hash (`0x...`) that contains the log. Use **`--evm-event-index`** (0-based) when that transaction emitted more than one relevant log and you need a specific index.
+
+### Multi-handler workflows and `--non-interactive`
+
+Use **`--non-interactive`** when the process must not answer any follow-up questions. With `--non-interactive`, the CLI requires **`--trigger-index`**: the 0-based index of the handler to run (first handler is `0`, second is `1`, and so on). Combine **`--target`**, **`--non-interactive`**, **`--trigger-index`**, and the HTTP or EVM flags that match the selected handler.
+
+Examples (see also `https://docs.chain.link/cre/reference/cli/workflow`):
+
+```bash
+cre workflow simulate my-workflow \
+  --non-interactive \
+  --trigger-index 0 \
+  --http-payload '{"key":"value"}' \
+  --target staging-settings
+```
+
+```bash
+cre workflow simulate my-workflow \
+  --non-interactive \
+  --trigger-index 1 \
+  --evm-tx-hash 0x420721d7d00130a03c5b525b2dbfd42550906ddb3075e8377f9bb5d1a5992f8e \
+  --evm-event-index 0 \
+  --target staging-settings
+```
+
+A **cron-only** workflow with a single handler often needs only `--target`. If the CLI still asks which handler to run, add `--non-interactive --trigger-index 0`. Run `cre workflow simulate --help` on the installed CLI to confirm flag names for that version.
+
+## Running a Simulation
+
+### Basic Command
+
+```bash
+cre workflow simulate <workflow-dir> --target <target-name>
+```
+
+| Flag | Description | When required |
+|------|-------------|---------------|
+| `--target` | Target configuration from `workflow.yaml` | Always (omitting prompts for target) |
+| `--non-interactive` | No prompts; you must supply handler index and trigger inputs | Automation and CI |
+| `--trigger-index` | 0-based handler index | With `--non-interactive` |
+| `--http-payload` | JSON string or path to JSON file for HTTP trigger body | HTTP trigger when a body is required or with `--non-interactive` |
+| `--evm-tx-hash` | Transaction hash `0x...` containing the log | EVM log trigger when a tx is required or with `--non-interactive` |
+| `--evm-event-index` | 0-based log index inside the transaction | When the tx has multiple events and you must pick one |
+| `--timeout` | Simulation timeout | No (default: 30s) |
+| `--broadcast` | Real onchain writes (MockKeystoneForwarder) | No |
+| `--limits` | Production limits profile or file | No |
+| `--skip-type-checks` | Skip TypeScript typecheck | No |
+
+### What Simulation Does
+
+1. Compiles workflow code to WebAssembly
+2. Runs the workflow locally using the specified target configuration
+3. Simulates trigger events (fires each trigger once)
+4. Executes capability calls against real endpoints (RPC, HTTP APIs)
+5. Displays output including user logs and the workflow result
+
+### Run Directory
+
+Always run simulation from the **project root directory** (the directory containing `project.yaml`), not from within the workflow subdirectory.
+
+```bash
+cd my-project
+cre workflow simulate my-workflow --target staging-settings
+```
+
+## Simulation by Trigger Type
+
+### Cron Trigger
+
+The simulator fires the cron trigger once immediately without waiting for the schedule.
+
+```bash
+cre workflow simulate my-workflow --target staging-settings
+```
+
+Expected output:
+
+```
+Workflow compiled
+[SIMULATION] Simulator Initialized
+[SIMULATION] Running trigger trigger=cron-trigger@1.0.0
+[USER LOG] Hello world! Workflow triggered.
+Workflow Simulation Result:
+ "Hello world!"
+[SIMULATION] Execution finished signal received
+```
+
+### HTTP Trigger
+
+**Interactive (human can use two terminals):** the simulator starts a local HTTP server on port 8080. Send a request from a separate terminal to trigger the workflow.
+
+Terminal 1 (start simulation):
+
+```bash
+cre workflow simulate my-workflow --target staging-settings
+```
+
+Output:
+
+```
+Workflow compiled
+[SIMULATION] Simulator Initialized
+[SIMULATION] HTTP trigger server started on :8080
+[SIMULATION] Waiting for HTTP request...
+```
+
+Terminal 2 (send trigger request):
+
+```bash
+curl -X POST http://localhost:8080/trigger \
+  -H "Content-Type: application/json" \
+  -d '{"key": "value"}'
+```
+
+After the curl request, Terminal 1 shows the workflow execution result.
+
+**Non-interactive (agents, CI):** pass the same JSON with **`--http-payload`**, and use **`--non-interactive`** with **`--trigger-index`** when the CLI would otherwise prompt for a body or for which handler to run. See the [Non-Interactive Rule](#non-interactive-rule) section.
+
+### EVM Log Trigger
+
+**Default:** the simulator can monitor the chain for matching log events using the RPC endpoint from `project.yaml`. The run may need a long **`--timeout`** because it waits for a matching event.
+
+```bash
+cre workflow simulate my-workflow --target staging-settings --timeout 120s
+```
+
+**Non-interactive (agents, CI):** pass **`--evm-tx-hash`** (and **`--evm-event-index`** if needed) so the CLI does not ask for a transaction. Use **`--non-interactive`** and **`--trigger-index`** as in the [Non-Interactive Rule](#non-interactive-rule) section.
+
+### Multi-Trigger Workflows
+
+In typical interactive use, the simulator can step through multiple handlers: cron may fire first, HTTP may start a local server, EVM log may monitor the chain, depending on CLI version and prompts.
+
+For **automation**, select one handler per run with **`--non-interactive`**, **`--target`**, **`--trigger-index`**, and the HTTP or EVM flags for that handler. To exercise another handler, run simulate again with a different **`--trigger-index`** and the right **`--http-payload`** or **`--evm-tx-hash`**.
+
+```bash
+cre workflow simulate my-workflow --target staging-settings
+```
+
+See [Non-Interactive Rule](#non-interactive-rule) for the full flag set.
+
+## Simulation vs Deployment
+
+| Aspect | Simulation | Deployment |
+|--------|-----------|------------|
+| Execution | Local machine | DON nodes |
+| Consensus | Single node (no aggregation) | Multi-node with consensus |
+| Gas costs | None | Real gas costs |
+| Secrets | From `.env` / environment | From Vault DON |
+| RPC calls | Direct to RPC endpoint | Via DON EVM client |
+| Onchain writes | Via MockKeystoneForwarder (with `--broadcast`) | Via KeystoneForwarder |
+
+## Onchain Write Simulation (--broadcast)
+
+To test onchain writes during simulation, use the `--broadcast` flag. This deploys a MockKeystoneForwarder and executes the write transaction on a real testnet.
+
+```bash
+cre workflow simulate my-workflow --target staging-settings --broadcast
+```
+
+This requires:
+- A funded wallet (private key in `.env`)
+- The consumer contract's forwarder address set to the MockKeystoneForwarder for the target chain (see chain-selectors.md for addresses)
+
+## Common Errors and Fixes
+
+### "Select a target" interactive prompt
+
+**Cause**: `--target` flag was omitted.
+
+**Fix**: Always include `--target`:
+
+```bash
+cre workflow simulate my-workflow --target staging-settings
+```
+
+### Prompts for HTTP body, EVM transaction hash, or trigger index
+
+**Cause**: The CLI needs input for an HTTP payload, an EVM log (tx hash and optional log index), or which handler to run in a multi-handler workflow, and no flag was passed.
+
+**Fix**: Add **`--http-payload`**, **`--evm-tx-hash`** / **`--evm-event-index`**, and for fully non-interactive runs **`--non-interactive`** with **`--trigger-index`**, as in the [Non-Interactive Rule](#non-interactive-rule) section.
+
+### Compilation error: "cannot find module"
+
+**Cause**: Dependencies not installed.
+
+**Fix (TypeScript)**:
+
+```bash
+cd my-workflow
+bun install
+bunx cre-setup
+cd ..
+```
+
+If `postinstall` already ran `cre-setup`, `bunx cre-setup` is redundant but safe. See project-scaffolding.md for why `cre-setup` must complete before leaving the workflow directory.
+
+**Fix (Go)**:
+
+```bash
+GOFLAGS=-mod=mod go mod tidy
+```
+
+### "secret not found" error
+
+**Cause**: Secret declared in `secrets.yaml` but not present in `.env` or environment, OR the env var name is a substring of the secret name (known bug in CRE CLI v1.1.0).
+
+**Fix**: Ensure the `.env` file contains the environment variable referenced in `secrets.yaml`. If the env var name is a prefix of the secret name, rename the env var to avoid the substring conflict (e.g., add a `_VAR` suffix).
+
+### "workflow-path not found" error
+
+**Cause**: Running simulation from the wrong directory, or `workflow.yaml` has an incorrect `workflow-path`.
+
+**Fix**: Run from the project root (where `project.yaml` is). Verify `workflow-path` in `workflow.yaml` points to the correct entry file relative to the workflow directory.
+
+### TypeScript: "X is not defined" (process, Buffer, crypto)
+
+**Cause**: Code or a dependency uses Node.js APIs that are not available in the QuickJS WASM runtime.
+
+**Fix**: Replace Node.js APIs with CRE equivalents:
+- `process.env.X` -> `runtime.getSecret("X")`
+- `Buffer.from(...)` -> `new Uint8Array(...)`
+- `crypto.randomBytes(...)` -> not available; use deterministic logic or Go workflows for randomness
+- See project-scaffolding.md for the full list of unsupported APIs
+
+### Go: "go mod tidy" hangs
+
+**Cause**: Module proxy is slow or the CRE SDK module requires special access.
+
+**Fix**: Try direct mode with a timeout:
+
+```bash
+GOPROXY=direct go mod tidy -v
+```
+
+If the module is in a private repository:
+
+```bash
+GONOSUMCHECK=github.com/smartcontractkit/* GONOSUMDB=github.com/smartcontractkit/* GOPROXY=direct go mod tidy
+```
+
+### Simulation timeout
+
+**Cause**: Default timeout (30s) may be too short for EVM log triggers or slow RPC endpoints.
+
+**Fix**: Increase the timeout:
+
+```bash
+cre workflow simulate my-workflow --target staging-settings --timeout 120s
+```
+
+## Official Documentation
+
+- Simulation guide: `https://docs.chain.link/cre/getting-started/overview`
+- Deploying workflows: `https://docs.chain.link/cre/guides/workflow/deploying-a-workflow`

--- a/chainlink-cre-skill/references/workflow-patterns.md
+++ b/chainlink-cre-skill/references/workflow-patterns.md
@@ -299,6 +299,118 @@ if err != nil {
 
 Execution is single-threaded. `.Await()` drives the event loop forward until the result is available.
 
+## Best Practices
+
+### One Workflow, Multiple Handlers
+
+If your triggers share the same project context (config, secrets, consumer contracts), register them as multiple handlers in a single `initWorkflow` / `InitWorkflow` function rather than creating separate workflows.
+
+#### TypeScript
+
+```typescript
+import {
+  CronCapability,
+  HTTPCapability,
+  EVMLogCapability,
+  handler,
+  Runner,
+  type Runtime,
+  type HTTPTriggerPayload,
+  type EVMLogPayload,
+} from "@chainlink/cre-sdk"
+
+type Config = {
+  schedule: string
+  contractAddress: string
+  chainSelectorName: string
+}
+
+const onCronTrigger = (runtime: Runtime<Config>): string => {
+  runtime.log("Cron triggered")
+  return "cron-result"
+}
+
+const onHttpTrigger = (runtime: Runtime<Config>, event: HTTPTriggerPayload): string => {
+  runtime.log(`HTTP triggered with body: ${JSON.stringify(event.body)}`)
+  return "http-result"
+}
+
+const onLogTrigger = (runtime: Runtime<Config>, event: EVMLogPayload): string => {
+  runtime.log(`EVM log from ${event.address}`)
+  return "log-result"
+}
+
+const initWorkflow = (config: Config) => {
+  const cron = new CronCapability()
+  const http = new HTTPCapability()
+  const evmLog = new EVMLogCapability()
+
+  return [
+    handler(cron.trigger({ schedule: config.schedule }), onCronTrigger),
+    handler(http.trigger({ authorizedKeys: [] }), onHttpTrigger),
+    handler(
+      evmLog.trigger({
+        contractAddress: config.contractAddress,
+        chainSelectorName: config.chainSelectorName,
+        eventSignature: "Transfer(address,address,uint256)",
+      }),
+      onLogTrigger,
+    ),
+  ]
+}
+
+export async function main() {
+  const runner = await Runner.newRunner<Config>()
+  await runner.run(initWorkflow)
+}
+```
+
+#### Go
+
+```go
+func InitWorkflow(config *Config) []cre.HandlerDefinition {
+    return []cre.HandlerDefinition{
+        cre.Handler(cron.Trigger(cron.Config{Schedule: config.Schedule}), onCronTrigger),
+        cre.Handler(
+            webhooktrigger.Trigger(webhooktrigger.Config{AuthorizedSenders: []string{}}),
+            onHTTPTrigger,
+        ),
+        cre.Handler(
+            evmlogtrigger.Trigger(evmlogtrigger.Config{
+                ContractAddress:   config.ContractAddress,
+                ChainSelectorName: config.ChainSelectorName,
+                EventSignature:    "Transfer(address,address,uint256)",
+            }),
+            onLogTrigger,
+        ),
+    }
+}
+```
+
+### When to Use Separate Workflows
+
+Create separate workflows only when:
+- The triggers operate on entirely different chains with no shared config
+- The workflows have different deployment lifecycles (one is stable, the other iterates frequently)
+- The workflows require different secrets namespaces
+- The workflows target different consumer contracts with no logical relationship
+
+### Avoid Duplicating Capability Instances
+
+Instantiate each capability once and share it across handlers:
+
+```typescript
+const initWorkflow = (config: Config) => {
+  const cron = new CronCapability()
+  const http = new HTTPCapability()
+
+  return [
+    handler(cron.trigger({ schedule: config.schedule }), onScheduledFetch),
+    handler(http.trigger({ authorizedKeys: [] }), onManualFetch),
+  ]
+}
+```
+
 ## Official Documentation
 
 - Secrets management: `https://docs.chain.link/cre/guides/workflow/secrets`

--- a/evals/chainlink-cre-skill/cases/functional/project-scaffolding-01.txt
+++ b/evals/chainlink-cre-skill/cases/functional/project-scaffolding-01.txt
@@ -1,0 +1,1 @@
+I want to set up a new CRE TypeScript project from scratch. Create the project, install dependencies, and run the first simulation. I'm running this in an automated environment where I can't interact with terminal prompts.

--- a/evals/chainlink-cre-skill/cases/functional/project-scaffolding-02.txt
+++ b/evals/chainlink-cre-skill/cases/functional/project-scaffolding-02.txt
@@ -1,0 +1,1 @@
+Create a new CRE Go project with a cron trigger that logs a message every minute. Set up the full project structure, install dependencies, and show me how to verify it works with a simulation. I need to do this non-interactively.

--- a/evals/chainlink-cre-skill/cases/functional/simulation-01.txt
+++ b/evals/chainlink-cre-skill/cases/functional/simulation-01.txt
@@ -1,0 +1,1 @@
+I have a CRE workflow with both a cron trigger and an HTTP trigger. How do I simulate it? My project has both staging-settings and production-settings targets. I want to test against staging.

--- a/evals/chainlink-cre-skill/cases/functional/workflow-generation-03.txt
+++ b/evals/chainlink-cre-skill/cases/functional/workflow-generation-03.txt
@@ -1,0 +1,1 @@
+I need a CRE TypeScript workflow with 3 different triggers: a cron schedule that runs every 5 minutes, an HTTP webhook for on-demand execution, and an EVM log listener that reacts to Transfer events on an ERC-20 contract on Ethereum Sepolia. Each trigger should call a different callback function. Generate the complete workflow code.

--- a/evals/chainlink-cre-skill/promptfooconfig.yaml
+++ b/evals/chainlink-cre-skill/promptfooconfig.yaml
@@ -61,6 +61,32 @@ tests:
       requires_live_source: "no"
     assert: *functional_asserts
 
+  - vars:
+      case_file: cases/functional/workflow-generation-03.txt
+      workflow: workflow-generation
+      requires_live_source: "no"
+    assert: *functional_asserts
+
+  # ── Functional: Project Scaffolding ──────────────────────────────────
+  - vars:
+      case_file: cases/functional/project-scaffolding-01.txt
+      workflow: project-scaffolding
+      requires_live_source: "no"
+    assert: *functional_asserts
+
+  - vars:
+      case_file: cases/functional/project-scaffolding-02.txt
+      workflow: project-scaffolding
+      requires_live_source: "no"
+    assert: *functional_asserts
+
+  # ── Functional: Simulation ───────────────────────────────────────────
+  - vars:
+      case_file: cases/functional/simulation-01.txt
+      workflow: simulation
+      requires_live_source: "no"
+    assert: *functional_asserts
+
   # ── Functional: HTTP Client ─────────────────────────────────────────
   - vars:
       case_file: cases/functional/http-client-01.txt


### PR DESCRIPTION
- Adds `simulation.md` with instructions for the agent on running non-interactively
- Adds `project-scaffolding.md` to provide information on CRE project structure
- Extends `cli-reference.md` with more information on flags
- Extends `SKILL.md` to provide better information on running non-interactively
- Extends `operations.md` to provide better information on flags (and reference `simulation.md`)
- Slims `getting-started.md` to cross-reference `project-scaffolding.md` and `simulation.md`