### PR TITLE
Fix eval skill reads

### DIFF
--- a/evals/chainlink-ace-skill/prompts/with-skill.js
+++ b/evals/chainlink-ace-skill/prompts/with-skill.js
@@ -5,7 +5,7 @@ module.exports = function ({ vars }) {
   const caseFile = vars.case_file;
   const content = fs.readFileSync(path.resolve(__dirname, "..", caseFile), "utf8").trim();
 
-  const skillPath = path.resolve(__dirname, "../../../chainlink-ace-skill/SKILL.md");
+  const skillPath = path.resolve(__dirname, "..", "..", "..", "chainlink-ace-skill", "SKILL.md");
   const skillContent = fs.readFileSync(skillPath, "utf8").trim();
 
   return [

--- a/evals/chainlink-ccip-skill/prompts/with-skill.js
+++ b/evals/chainlink-ccip-skill/prompts/with-skill.js
@@ -1,18 +1,15 @@
-const fs = require('fs');
-const path = require('path');
+const fs = require("fs");
+const path = require("path");
 
-module.exports = async function ({ vars }) {
-  const casePath = path.resolve(__dirname, '..', vars.case_file);
-  const skillPath = path.resolve(__dirname, '..', '..', '..', 'chainlink-ccip-skill', 'SKILL.md');
+module.exports = function ({ vars }) {
+  const caseFile = vars.case_file;
+  const content = fs.readFileSync(path.resolve(__dirname, "..", caseFile), "utf8").trim();
+
+  const skillPath = path.resolve(__dirname, "..", "..", "..", "chainlink-ccip-skill", "SKILL.md");
+  const skillContent = fs.readFileSync(skillPath, "utf8").trim();
 
   return [
-    {
-      role: 'system',
-      content: fs.readFileSync(skillPath, 'utf8'),
-    },
-    {
-      role: 'user',
-      content: fs.readFileSync(casePath, 'utf8').trim(),
-    },
+    { role: "system", content: skillContent },
+    { role: "user", content: content },
   ];
 };

--- a/evals/chainlink-cre-skill/prompts/with-skill.js
+++ b/evals/chainlink-cre-skill/prompts/with-skill.js
@@ -5,7 +5,7 @@ module.exports = function ({ vars }) {
   const caseFile = vars.case_file;
   const content = fs.readFileSync(path.resolve(__dirname, "..", caseFile), "utf8").trim();
 
-  const skillPath = path.resolve(__dirname, "../../chainlink-cre-skill/SKILL.md");
+  const skillPath = path.resolve(__dirname, "..", "..", "..", "chainlink-cre-skill", "SKILL.md");
   const skillContent = fs.readFileSync(skillPath, "utf8").trim();
 
   return [

--- a/evals/chainlink-data-feeds-skill/prompts/with-skill.js
+++ b/evals/chainlink-data-feeds-skill/prompts/with-skill.js
@@ -5,7 +5,7 @@ module.exports = function ({ vars }) {
   const caseFile = vars.case_file;
   const content = fs.readFileSync(path.resolve(__dirname, "..", caseFile), "utf8").trim();
 
-  const skillPath = path.resolve(__dirname, "../../chainlink-data-feeds-skill/SKILL.md");
+  const skillPath = path.resolve(__dirname, "..", "..", "..", "chainlink-data-feeds-skill", "SKILL.md");
   const skillContent = fs.readFileSync(skillPath, "utf8").trim();
 
   return [

--- a/evals/chainlink-data-streams-skill/prompts/with-skill.js
+++ b/evals/chainlink-data-streams-skill/prompts/with-skill.js
@@ -1,18 +1,15 @@
-const fs = require('fs');
-const path = require('path');
+const fs = require("fs");
+const path = require("path");
 
-module.exports = async function ({ vars }) {
-  const casePath = path.resolve(__dirname, '..', vars.case_file);
-  const skillPath = path.resolve(__dirname, '..', '..', '..', 'chainlink-data-streams-skill', 'SKILL.md');
+module.exports = function ({ vars }) {
+  const caseFile = vars.case_file;
+  const content = fs.readFileSync(path.resolve(__dirname, "..", caseFile), "utf8").trim();
+
+  const skillPath = path.resolve(__dirname, "..", "..", "..", "chainlink-data-streams-skill", "SKILL.md");
+  const skillContent = fs.readFileSync(skillPath, "utf8").trim();
 
   return [
-    {
-      role: 'system',
-      content: fs.readFileSync(skillPath, 'utf8'),
-    },
-    {
-      role: 'user',
-      content: fs.readFileSync(casePath, 'utf8').trim(),
-    },
+    { role: "system", content: skillContent },
+    { role: "user", content: content },
   ];
 };


### PR DESCRIPTION
Fixes eval prompt loaders to read each skill’s top-level `SKILL.md` via `__dirname`-anchored repo-root paths, matching the existing pattern from PR #25. Also normalizes CCIP and Data Streams loaders to the same sync message-array shape.