### PR TITLE
Add PR template and agent instruction

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,7 @@
+## Description
+
+A concise description of what the PR proposes. Explain what the change is doing.
+
+## Justification
+
+Why do we need this change?

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,5 +90,6 @@ Requires either API keys in `.env` (for promptfoo-based evals) or sufficient sub
 ## Conventions
 
 - Do not commit `.env` or secret files.
+- All PRs, including agent-authored PRs, must use `.github/PULL_REQUEST_TEMPLATE.md` and complete its Description and Justification sections.
 - Reference docs in `references/` should be kept factual and up to date with the latest Chainlink documentation.
 - Eval cases go in `evals/<skill-name>/cases/` organized by category (`functional/`, `trigger-positive/`, `trigger-negative/`).


### PR DESCRIPTION
## Description

Adds a repository-wide pull request template at `.github/PULL_REQUEST_TEMPLATE.md` with required `Description` and `Justification` sections. Updates `CLAUDE.md` so all contributors, including agents, are instructed to use the template when opening PRs.

## Justification

We need a consistent PR format so every change clearly explains what it does and why it is needed. This also ensures agent-authored PRs follow the same review expectations as human-authored PRs.