### PR TITLE
Specify user login auth flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ node_modules/
 dist/
 build/
 *.tsbuildinfo
+.npm-cache/
 
 # Env and secrets
 .env

--- a/chainlink-cre-skill/SKILL.md
+++ b/chainlink-cre-skill/SKILL.md
@@ -6,7 +6,7 @@ compatibility: Designed for AI agents that implement https://agentskills.io/spec
 allowed-tools: Read WebFetch Write Edit Bash
 metadata:
   purpose: CRE developer onboarding, assistance and reference
-  version: "0.0.8"
+  version: "0.0.9"
 ---
 
 # Chainlink CRE Skill
@@ -55,6 +55,7 @@ Route CRE requests to the simplest valid path. Keep this file as the decision la
 7. Preserve user-specified schedules, thresholds, units, decimals, chain identifiers, addresses, resource IDs, and secret names across code, config, README, tests, and simulation examples.
 8. Keep secrets as references. Do not put real credentials, private keys, bearer tokens, webhook URLs, or API keys in config, README examples, or tests.
 9. If a workflow depends on a contract, API, relay, database, queue, notification endpoint, or operator action, include the minimal interface, mock, adapter, or boundary needed to make the artifact coherent.
+10. Account creation is a browser-only flow (email verification, password, 2FA, recovery code) that only the user can complete. Do not attempt to automate it; instruct the user to sign up at `https://cre.chain.link` themselves. For login, the agent may run `cre login`, but it opens a browser where the user must complete the interactive sign-in (entering their password, plus 2FA if enabled on their account). Run the command, tell the user to finish logging in in their browser, then continue the task once the command returns / the user confirms (e.g., via `cre whoami`).
 
 ## Documentation and Freshness
 

--- a/chainlink-cre-skill/references/cli-reference.md
+++ b/chainlink-cre-skill/references/cli-reference.md
@@ -30,7 +30,7 @@ Key rules:
 
 ### `cre login`
 
-Authenticate with the CRE platform. Opens a browser for interactive login with 2FA.
+Authenticate with the CRE platform. Opens a browser for interactive login (password, plus 2FA if enabled). The agent can run this command, but the user must complete the browser-based sign-in themselves; the agent continues once the command returns.
 
 ```bash
 cre login

--- a/chainlink-cre-skill/references/getting-started.md
+++ b/chainlink-cre-skill/references/getting-started.md
@@ -51,7 +51,11 @@ cre update
 
 ## Account Setup
 
+> **Some steps need the user's browser.** Account creation is a browser-only flow (email verification, password, 2FA, recovery code) the user must do themselves. For login, the agent can run `cre login`, but the command opens a browser where the user completes the interactive sign-in by entering their password (and 2FA if enabled); once they finish and the command returns, the agent can continue its task.
+
 ### Creating an Account
+
+The user must complete these steps themselves in a web browser:
 
 1. Go to `https://cre.chain.link` and click "Sign Up"
 2. Choose "Create a new organization" or "Join an existing organization"
@@ -62,11 +66,13 @@ cre update
 
 ### CLI Login
 
+The agent can run this command:
+
 ```bash
 cre login
 ```
 
-This opens a browser window for authentication. Complete 2FA when prompted. On success:
+This opens a browser window for authentication, where the user must interactively sign in by entering their password (and 2FA if enabled) — the agent cannot do that part for them. Run the command, tell the user to finish logging in in their browser, and continue once it returns. On success:
 
 ```
 Account details retrieved:

--- a/chainlink-cre-skill/references/operations.md
+++ b/chainlink-cre-skill/references/operations.md
@@ -38,7 +38,7 @@ Always include `--target`. For `cre workflow simulate` only, the CLI can also pr
 ### Prerequisites
 
 1. **Early Access approval**: Deployment requires being approved for the CRE Early Access program
-2. **Authentication**: Run `cre login` and complete 2FA
+2. **Authentication**: Run `cre login`; it opens a browser where the user completes the interactive sign-in (password, plus 2FA if enabled), then the agent continues
 3. **Linked wallet**: Run `cre account link-key --target <target>` to link a funded wallet
 4. **Funded wallet**: Wallet needs ETH on the target chain for gas fees
 5. **Secrets uploaded**: If the workflow uses secrets, run `cre secrets create` first


### PR DESCRIPTION
  ## Description
  
  Updates the `chainlink-cre-skill` to clarify the account setup and login authentication
  flow, distinguishing what an agent can and cannot do on the user's behalf:

  - Account creation is a browser-only flow the user must complete themselves (sign up at
  https://cre.chain.link).
  - `cre login` can be run by the agent, but it opens a browser where the user must complete
  the interactive sign-in by entering their password (and 2FA if enabled on their account).
  The agent runs the command, instructs the user to finish logging in, and continues the
  task once the command returns.

  Changes span:
  - `SKILL.md` — new Hard Guardrail (`#10`) so the decision layer surfaces this without loading
  a reference; patch version bumped to `0.0.9`.
  - `references/getting-started.md` — added a callout and reworded the Account Setup and CLI
  Login sections.
  - `references/cli-reference.md` — clarified the `cre login` command entry.
  - `references/operations.md` — updated the deployment Authentication prerequisite.
  
  Also adds `.npm-cache/` to `.gitignore`.

  ## Justification

  The skill previously implied account creation and login were ordinary CLI steps an agent
  could fully automate. In reality these are interactive, browser-based flows that require
  the human. Without this clarification, an agent could stall waiting on a step it cannot
  perform, or incorrectly tell the user it had logged them in. The updated guidance sets the
  right expectation: the agent handles its part (running `cre login`), hands off the browser
  sign-in to the user, and resumes once authentication completes. The 2FA wording was
  softened to "if enabled" since it is not required on every account.