### PR TITLE
Require cre init for new projects

### DIFF
--- a/chainlink-cre-skill/SKILL.md
+++ b/chainlink-cre-skill/SKILL.md
@@ -6,7 +6,7 @@ compatibility: Designed for AI agents that implement https://agentskills.io/spec
 allowed-tools: Read WebFetch Write Edit Bash
 metadata:
   purpose: CRE developer onboarding, assistance and reference
-  version: "0.0.11"
+  version: "0.0.12"
 ---
 
 # Chainlink CRE Skill
@@ -56,7 +56,8 @@ Route CRE requests to the simplest valid path. Keep this file as the decision la
 7. Preserve user-specified schedules, thresholds, units, decimals, chain identifiers, addresses, resource IDs, and secret names across code, config, README, tests, and simulation examples.
 8. Keep secrets as references. Do not put real credentials, private keys, bearer tokens, webhook URLs, or API keys in config, README examples, or tests.
 9. If a workflow depends on a contract, API, relay, database, queue, notification endpoint, or operator action, include the minimal interface, mock, adapter, or boundary needed to make the artifact coherent.
-10. Account creation is a browser-only flow (email verification, password, 2FA, recovery code) that only the user can complete. Do not attempt to automate it; instruct the user to sign up at `https://cre.chain.link` themselves. For login, the agent may run `cre login`, but it opens a browser where the user must complete the interactive sign-in (entering their password, plus 2FA if enabled on their account). Run the command, tell the user to finish logging in in their browser, then continue the task once the command returns / the user confirms (e.g., via `cre whoami`).
+10. Always create new CRE projects with `cre init` (see `project-scaffolding.md`). Never hand-write project structure, config, or boilerplate yourself unless `cre init` is unavailable or fails.
+11. Account creation is a browser-only flow (email verification, password, 2FA, recovery code) that only the user can complete. Do not attempt to automate it; instruct the user to sign up at `https://cre.chain.link` themselves. For login, the agent may run `cre login`, but it opens a browser where the user must complete the interactive sign-in (entering their password, plus 2FA if enabled on their account). Run the command, tell the user to finish logging in in their browser, then continue the task once the command returns / the user confirms (e.g., via `cre whoami`).
 
 ## Documentation and Freshness
 

--- a/chainlink-cre-skill/references/project-scaffolding.md
+++ b/chainlink-cre-skill/references/project-scaffolding.md
@@ -14,9 +14,9 @@ Do not use for CLI installation or account setup (see getting-started.md), simul
 
 ## Project Creation
 
-Prefer `cre init` with `--non-interactive` and explicit flags. This generates the correct project structure without requiring human input. Fall back to manual scaffolding from the templates below only if `cre init` is unavailable or fails.
+Always use `cre init` with `--non-interactive` and explicit flags to create new projects. This generates the correct project structure without requiring human input. Never hand-write the project structure, config, or boilerplate yourself; the manual templates below are a last-resort fallback only if `cre init` is unavailable or fails.
 
-### Using `cre init` (Preferred)
+### Using `cre init`
 
 `cre init` supports non-interactive mode via the `--non-interactive` flag. Always use this mode when running as an agent.
 


### PR DESCRIPTION
  ## Description

  Makes it explicit that agents using the CRE skill must create new
  projects with `cre init` rather than hand-writing scaffolding.

  - **`chainlink-cre-skill/SKILL.md`**: Added Hard Guardrail `#10` — always
    create new CRE projects with `cre init`; never hand-write project
    structure, config, or boilerplate unless `cre init` is unavailable or
    fails. This lives in the always-loaded decision layer, so it applies
    before the scaffolding reference is even read.
  - **`chainlink-cre-skill/references/project-scaffolding.md`**: Reworded
    "Project Creation" from "Prefer `cre init`" to "Always use `cre init`",
    and reframed the manual templates as a last-resort fallback.
  - Bumped skill `metadata.version` per repo convention.

  The manual templates remain intact as a genuine fallback for `cre init`
  failures.

  ## Justification

  Agents were sometimes scaffolding CRE projects by hand, producing
  structures that drift from what `cre init` generates. `cre init` is the
  source of truth for correct project layout, so the skill should mandate
  it. The change is intentionally minimal — one guardrail line plus a
  one-sentence wording change — to keep the skill lean.