### PR TITLE
Add VRF starter kit example

### DIFF
--- a/chainlink-vrf-skill/SKILL.md
+++ b/chainlink-vrf-skill/SKILL.md
@@ -19,6 +19,7 @@ Route VRF requests to the simplest valid path while keeping side effects and cre
 
 1. Keep this file as the default guide.
 2. Read [references/subscription.md](references/subscription.md) only when the user wants to build a subscription-based consumer, manage a subscription, use `VRFConsumerBaseV2Plus`, call `requestRandomWords`, or handle the `fulfillRandomWords` callback.
+   2a. Read [templates/starter-kit/README.md](templates/starter-kit/README.md) and the files in [templates/starter-kit](templates/starter-kit) when the user asks for a working example project, Foundry starter kit, runnable VRF example, or says something like "give me a working VRF project I can build and test." Use this starter-kit template instead of inventing project scaffolding.
 3. Read [references/direct-funding.md](references/direct-funding.md) only when the user wants direct funding (no subscription), uses `VRFV2PlusWrapperConsumerBase`, or asks about a one-off randomness request.
 4. Read [references/migration-from-v2.md](references/migration-from-v2.md) when you detect V1 or V2 patterns in user-supplied code (`VRFConsumerBaseV2`, `VRFConsumerBase`, positional `requestRandomWords`, `uint64` subscription IDs, `VRFV2WrapperConsumerBase`, or `memory` randomWords in a subscription consumer) or when the user asks how to migrate.
 5. Read [references/billing.md](references/billing.md) only when the user asks about costs, LINK vs native payment, subscription funding, or premium percentages.
@@ -30,6 +31,7 @@ Route VRF requests to the simplest valid path while keeping side effects and cre
 ## Routing
 
 1. **Subscription (default)**: Use for recurring randomness, games, lotteries, any contract that requests randomness more than once. Route to `subscription.md`.
+   1a. **Starter kit / runnable project**: For project-level example requests, especially Foundry starter requests, use `templates/starter-kit`. Return a concise file tree, the relevant template files, install/test commands, and the Sepolia VRF v2.5 coordinator + key hash configuration unless the user asks for another chain. Preserve the template's Foundry layout and `VRFConsumerV2Plus` (v2.5) contract unless the user asks for a different framework.
 2. **Direct funding**: Use for one-off requests or when the user explicitly does not want a subscription. Route to `direct-funding.md`.
 3. **Migration**: Detect legacy patterns (see Progressive Disclosure rule 4). Refuse to generate V2 code; load `migration-from-v2.md` and offer a v2.5 upgrade.
 4. **Network lookup**: When an address or key hash is needed, load `supported-networks.md`. Never invent coordinator or wrapper addresses.

--- a/chainlink-vrf-skill/SKILL.md
+++ b/chainlink-vrf-skill/SKILL.md
@@ -6,7 +6,7 @@ compatibility: Designed for AI agents that implement https://agentskills.io/spec
 allowed-tools: Read WebFetch Write Edit
 metadata:
   purpose: Chainlink VRF v2.5 developer assistance and reference
-  version: "0.0.3"
+  version: "0.0.4"
 ---
 
 # Chainlink VRF Skill

--- a/chainlink-vrf-skill/templates/starter-kit/.gitignore
+++ b/chainlink-vrf-skill/templates/starter-kit/.gitignore
@@ -1,0 +1,4 @@
+cache/
+out/
+
+.env

--- a/chainlink-vrf-skill/templates/starter-kit/README.md
+++ b/chainlink-vrf-skill/templates/starter-kit/README.md
@@ -1,0 +1,67 @@
+# Chainlink VRF Foundry Starter Kit Template
+
+Use this template when a user asks for a working VRF project, a Foundry starter kit, or a runnable randomness example. It is based on the Chainlink Foundry Starter Kit `VRFConsumerV2.sol` pattern, **upgraded to VRF v2.5** (`VRFConsumerBaseV2Plus`) to match this skill's safety defaults — the legacy V2 base, `uint64` subscription IDs, and positional `requestRandomWords` arguments do not compile against current coordinators.
+
+## Files
+
+```text
+foundry.toml
+remappings.txt
+src/VRFConsumerV2Plus.sol
+script/VRFConsumerV2Plus.s.sol
+test/VRFConsumerV2Plus.t.sol
+```
+
+The test and deploy script use `VRFCoordinatorV2_5Mock` shipped with `@chainlink/contracts`, so no custom mocks are vendored.
+
+## Dependencies
+
+For a fresh Foundry project, install these dependencies before running the template:
+
+```sh
+forge install foundry-rs/forge-std
+forge install smartcontractkit/chainlink-evm@contracts-v1.5.0
+forge install openzeppelin/openzeppelin-contracts@v4.9.6
+```
+
+The included `remappings.txt` expects Chainlink contracts under `lib/chainlink-evm/`, OpenZeppelin v4.9.6 under `lib/openzeppelin-contracts/`, and forge-std under `lib/forge-std/`.
+
+## VRF v2.5 Essentials
+
+The consumer uses the subscription method:
+
+- Inherits `VRFConsumerBaseV2Plus` and requests via the `VRFV2PlusClient.RandomWordsRequest` struct with `extraArgs`.
+- Subscription IDs are `uint256`.
+- `fulfillRandomWords` takes `calldata` random words.
+- `extraArgs` selects the payment token per request: `nativePayment: false` pays in LINK, `true` pays in native coin. Fund the subscription with the matching token.
+
+Before deploying to a live network: create and fund a subscription at https://vrf.chain.link, then add the deployed consumer as an approved consumer for that subscription ID.
+
+## Default Network
+
+The deploy script defaults to Ethereum Sepolia, using the live VRF v2.5 coordinator and 500 gwei key hash:
+
+```text
+Coordinator: 0x9DdfaCa8183c41ad55329BdeeD9F6A8d53168B1B
+Key hash:    0x787d74caea10b2b357790d5b5247c2f63d1d91572a9846f780606e4d953677ae
+```
+
+On Sepolia the script reads the subscription ID from the `SUBSCRIPTION_ID` environment variable. On any other chain (e.g. a local Anvil node) it deploys a mock coordinator, creates and funds a subscription, and wires everything up so the project is runnable end-to-end.
+
+Always verify coordinator addresses and key hashes against the official Chainlink docs (https://docs.chain.link/vrf/v2-5/supported-networks) before deploying.
+
+## Commands
+
+```sh
+forge test
+
+# Local dry run (deploys and wires up a mock coordinator):
+forge script script/VRFConsumerV2Plus.s.sol:DeployVRFConsumerV2Plus
+
+# Sepolia (requires a funded subscription):
+SUBSCRIPTION_ID=<your-sub-id> \
+  forge script script/VRFConsumerV2Plus.s.sol:DeployVRFConsumerV2Plus \
+  --rpc-url $SEPOLIA_RPC_URL --private-key $PRIVATE_KEY --broadcast
+```
+
+Example code is unaudited and should be reviewed before production use.

--- a/chainlink-vrf-skill/templates/starter-kit/foundry.toml
+++ b/chainlink-vrf-skill/templates/starter-kit/foundry.toml
@@ -1,0 +1,6 @@
+[profile.default]
+src = "src"
+out = "out"
+libs = ["lib"]
+optimizer = true
+optimizer_runs = 20000

--- a/chainlink-vrf-skill/templates/starter-kit/remappings.txt
+++ b/chainlink-vrf-skill/templates/starter-kit/remappings.txt
@@ -1,0 +1,3 @@
+@chainlink/=lib/chainlink-evm/
+@openzeppelin/contracts@4.9.6/=lib/openzeppelin-contracts/contracts/
+forge-std/=lib/forge-std/src/

--- a/chainlink-vrf-skill/templates/starter-kit/script/VRFConsumerV2Plus.s.sol
+++ b/chainlink-vrf-skill/templates/starter-kit/script/VRFConsumerV2Plus.s.sol
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+import {Script} from "forge-std/Script.sol";
+import {VRFConsumerV2Plus} from "../src/VRFConsumerV2Plus.sol";
+import {VRFCoordinatorV2_5Mock} from "@chainlink/contracts/src/v0.8/vrf/mocks/VRFCoordinatorV2_5Mock.sol";
+
+/**
+ * @notice Deploys VRFConsumerV2Plus.
+ *
+ * On Ethereum Sepolia (chainid 11155111) it wires the consumer to the live VRF v2.5 coordinator and
+ * 500 gwei key hash, reading the subscription ID from the SUBSCRIPTION_ID env var. Create and fund a
+ * subscription at https://vrf.chain.link, then add the deployed contract as a consumer.
+ *
+ * On any other chain (e.g. a local Anvil node) it deploys a VRFCoordinatorV2_5Mock, creates and funds
+ * a subscription, deploys the consumer, and adds it as a consumer so the project is runnable end-to-end.
+ *
+ * Always verify coordinator addresses and key hashes against https://docs.chain.link/vrf/v2-5/supported-networks
+ * before deploying.
+ */
+contract DeployVRFConsumerV2Plus is Script {
+    // Ethereum Sepolia VRF v2.5 configuration.
+    address internal constant SEPOLIA_VRF_COORDINATOR = 0x9DdfaCa8183c41ad55329BdeeD9F6A8d53168B1B;
+    bytes32 internal constant SEPOLIA_KEY_HASH_500_GWEI =
+        0x787d74caea10b2b357790d5b5247c2f63d1d91572a9846f780606e4d953677ae;
+
+    // Local mock configuration.
+    uint96 internal constant BASE_FEE = 0.1 ether;
+    uint96 internal constant GAS_PRICE_LINK = 1e9;
+    int256 internal constant WEI_PER_UNIT_LINK = 4e15;
+    uint256 internal constant FUND_AMOUNT = 100 ether;
+
+    function run() external returns (VRFConsumerV2Plus consumer) {
+        if (block.chainid == 11155111) {
+            uint256 subscriptionId = vm.envUint("SUBSCRIPTION_ID");
+
+            vm.startBroadcast();
+            consumer = new VRFConsumerV2Plus(SEPOLIA_VRF_COORDINATOR, subscriptionId, SEPOLIA_KEY_HASH_500_GWEI);
+            vm.stopBroadcast();
+        } else {
+            vm.startBroadcast();
+            VRFCoordinatorV2_5Mock coordinator =
+                new VRFCoordinatorV2_5Mock(BASE_FEE, GAS_PRICE_LINK, WEI_PER_UNIT_LINK);
+            uint256 subscriptionId = coordinator.createSubscription();
+            coordinator.fundSubscription(subscriptionId, FUND_AMOUNT);
+            consumer = new VRFConsumerV2Plus(address(coordinator), subscriptionId, bytes32(0));
+            coordinator.addConsumer(subscriptionId, address(consumer));
+            vm.stopBroadcast();
+        }
+
+        return consumer;
+    }
+}

--- a/chainlink-vrf-skill/templates/starter-kit/src/VRFConsumerV2Plus.sol
+++ b/chainlink-vrf-skill/templates/starter-kit/src/VRFConsumerV2Plus.sol
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: MIT
+// An example of a consumer contract that relies on a VRF v2.5 subscription for funding.
+pragma solidity ^0.8.19;
+
+import {VRFConsumerBaseV2Plus} from "@chainlink/contracts/src/v0.8/vrf/dev/VRFConsumerBaseV2Plus.sol";
+import {VRFV2PlusClient} from "@chainlink/contracts/src/v0.8/vrf/dev/libraries/VRFV2PlusClient.sol";
+
+/**
+ * @title VRFConsumerV2Plus
+ * @notice A Chainlink VRF v2.5 subscription consumer that requests and stores random words.
+ * @dev Uses VRFConsumerBaseV2Plus (v2.5). The legacy VRFConsumerBaseV2 base, uint64 subscription
+ *      IDs, and positional requestRandomWords arguments do not compile against current coordinators.
+ */
+contract VRFConsumerV2Plus is VRFConsumerBaseV2Plus {
+    event RequestSent(uint256 requestId, uint32 numWords);
+    event RequestFulfilled(uint256 requestId, uint256[] randomWords);
+
+    struct RequestStatus {
+        bool fulfilled;
+        bool exists;
+        uint256[] randomWords;
+    }
+
+    // requestId => RequestStatus
+    mapping(uint256 => RequestStatus) public s_requests;
+
+    // Your subscription ID. uint256 in v2.5 (was uint64 in V2).
+    uint256 public s_subscriptionId;
+
+    // Past request IDs and the most recent one.
+    uint256[] public requestIds;
+    uint256 public lastRequestId;
+
+    // The gas lane to use, which specifies the maximum gas price to bump to.
+    // Copy the key hash for your network from the Chainlink docs / supported-networks reference.
+    bytes32 public keyHash;
+
+    // Depends on the number of requested values you want sent to fulfillRandomWords().
+    // Storing each word costs about 20,000 gas, so 100,000 is a safe default for this example.
+    // Test and adjust this limit based on the network, request size, and callback processing.
+    uint32 public callbackGasLimit = 100_000;
+
+    // The default is 3, but you can set this higher for more security against reorgs.
+    uint16 public requestConfirmations = 3;
+
+    // For this example, retrieve 2 random values in one request.
+    // Cannot exceed VRFCoordinatorV2_5.MAX_NUM_WORDS.
+    uint32 public numWords = 2;
+
+    /**
+     * @notice Constructor inherits VRFConsumerBaseV2Plus.
+     * @param vrfCoordinator the VRF coordinator address for your network.
+     * @param subscriptionId the subscription ID that this contract uses for funding requests.
+     * @param _keyHash the gas lane to use, which specifies the maximum gas price to bump to.
+     */
+    constructor(address vrfCoordinator, uint256 subscriptionId, bytes32 _keyHash)
+        VRFConsumerBaseV2Plus(vrfCoordinator)
+    {
+        s_subscriptionId = subscriptionId;
+        keyHash = _keyHash;
+    }
+
+    /**
+     * @notice Requests randomness from the VRF coordinator.
+     * @dev Assumes the subscription is funded sufficiently and this contract is an approved consumer.
+     * @param enableNativePayment true = pay in native coin, false = pay in LINK. Pass true only if
+     *        the subscription is funded with native coin.
+     */
+    function requestRandomWords(bool enableNativePayment) external onlyOwner returns (uint256 requestId) {
+        // Will revert if the subscription is not set and funded.
+        requestId = s_vrfCoordinator.requestRandomWords(
+            VRFV2PlusClient.RandomWordsRequest({
+                keyHash: keyHash,
+                subId: s_subscriptionId,
+                requestConfirmations: requestConfirmations,
+                callbackGasLimit: callbackGasLimit,
+                numWords: numWords,
+                extraArgs: VRFV2PlusClient._argsToBytes(
+                    VRFV2PlusClient.ExtraArgsV1({nativePayment: enableNativePayment})
+                )
+            })
+        );
+        s_requests[requestId] = RequestStatus({randomWords: new uint256[](0), exists: true, fulfilled: false});
+        requestIds.push(requestId);
+        lastRequestId = requestId;
+        emit RequestSent(requestId, numWords);
+        return requestId;
+    }
+
+    /**
+     * @notice Callback used by the VRF coordinator to deliver randomness.
+     * @dev v2.5 requires the random words to be `calldata` (V2 used `memory`).
+     * @param _requestId id of the request.
+     * @param _randomWords array of random results from the VRF coordinator.
+     */
+    function fulfillRandomWords(uint256 _requestId, uint256[] calldata _randomWords) internal override {
+        require(s_requests[_requestId].exists, "request not found");
+        s_requests[_requestId].fulfilled = true;
+        s_requests[_requestId].randomWords = _randomWords;
+        emit RequestFulfilled(_requestId, _randomWords);
+    }
+
+    /**
+     * @notice Returns the fulfillment status and random words for a request.
+     */
+    function getRequestStatus(uint256 _requestId)
+        external
+        view
+        returns (bool fulfilled, uint256[] memory randomWords)
+    {
+        require(s_requests[_requestId].exists, "request not found");
+        RequestStatus memory request = s_requests[_requestId];
+        return (request.fulfilled, request.randomWords);
+    }
+}

--- a/chainlink-vrf-skill/templates/starter-kit/test/VRFConsumerV2Plus.t.sol
+++ b/chainlink-vrf-skill/templates/starter-kit/test/VRFConsumerV2Plus.t.sol
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+import {Test} from "forge-std/Test.sol";
+import {VRFConsumerV2Plus} from "../src/VRFConsumerV2Plus.sol";
+import {VRFCoordinatorV2_5Mock} from "@chainlink/contracts/src/v0.8/vrf/mocks/VRFCoordinatorV2_5Mock.sol";
+
+contract VRFConsumerV2PlusTest is Test {
+    // Mock coordinator configuration.
+    uint96 public constant BASE_FEE = 0.1 ether;
+    uint96 public constant GAS_PRICE_LINK = 1e9;
+    int256 public constant WEI_PER_UNIT_LINK = 4e15;
+    uint256 public constant FUND_AMOUNT = 100 ether;
+
+    bytes32 public constant KEY_HASH = keccak256("test-key-hash");
+
+    VRFCoordinatorV2_5Mock public coordinator;
+    VRFConsumerV2Plus public consumer;
+    uint256 public subId;
+
+    event RequestSent(uint256 requestId, uint32 numWords);
+    event RequestFulfilled(uint256 requestId, uint256[] randomWords);
+
+    function setUp() public {
+        coordinator = new VRFCoordinatorV2_5Mock(BASE_FEE, GAS_PRICE_LINK, WEI_PER_UNIT_LINK);
+        subId = coordinator.createSubscription();
+        coordinator.fundSubscription(subId, FUND_AMOUNT);
+        consumer = new VRFConsumerV2Plus(address(coordinator), subId, KEY_HASH);
+        coordinator.addConsumer(subId, address(consumer));
+    }
+
+    function testCanRequestRandomness() public {
+        uint256 requestId = consumer.requestRandomWords(false);
+        assertEq(consumer.lastRequestId(), requestId);
+
+        (bool fulfilled,) = consumer.getRequestStatus(requestId);
+        assertFalse(fulfilled);
+    }
+
+    function testCanGetRandomResponse() public {
+        uint256 requestId = consumer.requestRandomWords(false);
+
+        // When testing locally you MUST call fulfillRandomWords yourself, since there is no
+        // Chainlink VRF node on your local network.
+        coordinator.fulfillRandomWords(requestId, address(consumer));
+
+        (bool fulfilled, uint256[] memory randomWords) = consumer.getRequestStatus(requestId);
+        assertTrue(fulfilled);
+        assertEq(randomWords.length, consumer.numWords());
+    }
+
+    function testEmitsEventOnRequest() public {
+        // Topics are unknown ahead of time; check that the event with numWords is emitted.
+        vm.expectEmit(false, false, false, true);
+        emit RequestSent(1, consumer.numWords());
+        consumer.requestRandomWords(false);
+    }
+
+    function testOnlyOwnerCanRequest() public {
+        vm.prank(address(0xBEEF));
+        vm.expectRevert();
+        consumer.requestRandomWords(false);
+    }
+}

--- a/evals/chainlink-vrf-skill/README.md
+++ b/evals/chainlink-vrf-skill/README.md
@@ -1,6 +1,6 @@
 # Chainlink VRF Skill Evals
 
-Evaluation suite for `chainlink-vrf-skill`. All 7 cases are smoke-tagged and run in CI.
+Evaluation suite for `chainlink-vrf-skill`. 10 cases total; 9 are smoke-tagged and run in CI.
 
 ## Running Evals
 
@@ -16,8 +16,8 @@ Run agent evals for chainlink-vrf-skill
 
 ```bash
 source ../../.env
-npx promptfoo eval --filter-metadata "smoke=true"   # smoke tier (all 7 cases)
-npx promptfoo eval                                    # full suite (same for now)
+npx promptfoo eval --filter-metadata "smoke=true"   # smoke tier (9 cases)
+npx promptfoo eval                                    # full suite (10 cases)
 npx promptfoo view
 ```
 
@@ -29,8 +29,11 @@ npx promptfoo view
 | `functional/subscription-02.txt` | functional | Add LINK-paid path to existing subscription consumer |
 | `functional/direct-funding-01.txt` | functional | Direct funding consumer on Arbitrum, native payment |
 | `functional/migration-01.txt` | functional | V2 → v2.5 migration, all breaking changes applied |
+| `functional/starter-kit-01.txt` | functional | Scaffolds the v2.5 Foundry starter-kit project (build + test locally) |
+| `functional/starter-kit-02.txt` | functional | Scaffolds the starter kit for Sepolia with deploy script and tests |
 | `trigger-positive/subscription-01.txt` | trigger+ | Generic randomness question triggers VRF skill |
 | `trigger-positive/legacy-trap-01.txt` | trigger+ | V2 code triggers skill + migration warning |
+| `trigger-positive/starter-kit-01.txt` | trigger+ | Runnable Foundry project request triggers VRF skill |
 | `trigger-negative/data-feeds-01.txt` | trigger- | Price feed question does NOT trigger VRF skill |
 
 ## Key Assertions (must-pass.txt)

--- a/evals/chainlink-vrf-skill/cases/functional/starter-kit-01.txt
+++ b/evals/chainlink-vrf-skill/cases/functional/starter-kit-01.txt
@@ -1,0 +1,1 @@
+Give me a working example of a Chainlink VRF project that I can build and test locally.

--- a/evals/chainlink-vrf-skill/cases/functional/starter-kit-02.txt
+++ b/evals/chainlink-vrf-skill/cases/functional/starter-kit-02.txt
@@ -1,0 +1,1 @@
+Scaffold a Foundry starter kit for requesting random words on Sepolia with Chainlink VRF, including a deploy script and tests I can run with `forge test`.

--- a/evals/chainlink-vrf-skill/cases/trigger-positive/starter-kit-01.txt
+++ b/evals/chainlink-vrf-skill/cases/trigger-positive/starter-kit-01.txt
@@ -1,0 +1,1 @@
+Can you set me up with a runnable Foundry project for getting random numbers from Chainlink?

--- a/evals/chainlink-vrf-skill/promptfooconfig.yaml
+++ b/evals/chainlink-vrf-skill/promptfooconfig.yaml
@@ -47,6 +47,20 @@ functional_asserts: &functional_asserts
   - type: llm-rubric
     value: file://rubrics/clarification.txt
 
+starter_kit_asserts: &starter_kit_asserts
+  - type: llm-rubric
+    value: file://rubrics/correctness.txt
+  - type: llm-rubric
+    value: file://rubrics/completeness.txt
+  - type: llm-rubric
+    value: file://rubrics/safety.txt
+  - type: llm-rubric
+    value: file://rubrics/freshness.txt
+  - type: llm-rubric
+    value: file://rubrics/clarification.txt
+  - type: llm-rubric
+    value: file://rubrics/starter-kit.txt
+
 tests:
   # ── Functional: Subscription ──────────────────────────────────────────
   - vars:
@@ -108,6 +122,26 @@ tests:
       smoke: true
     assert: *functional_asserts
 
+  # ── Functional: Starter Kit ───────────────────────────────────────────
+  - vars:
+      case_file: cases/functional/starter-kit-01.txt
+      workflow: starter-kit
+      requires_live_source: "no"
+    metadata:
+      workflow: starter-kit
+      category: functional
+      smoke: true
+    assert: *starter_kit_asserts
+
+  - vars:
+      case_file: cases/functional/starter-kit-02.txt
+      workflow: starter-kit
+      requires_live_source: "no"
+    metadata:
+      workflow: starter-kit
+      category: functional
+    assert: *starter_kit_asserts
+
   # ── Trigger Positive ─────────────────────────────────────────────────
   - vars:
       case_file: cases/trigger-positive/subscription-01.txt
@@ -131,6 +165,16 @@ tests:
         - references/supported-networks.md
     metadata:
       workflow: migration
+      category: trigger-positive
+      smoke: true
+    assert: *trigger_positive_asserts
+
+  - vars:
+      case_file: cases/trigger-positive/starter-kit-01.txt
+      workflow: starter-kit
+      expected_trigger: "yes"
+    metadata:
+      workflow: starter-kit
       category: trigger-positive
       smoke: true
     assert: *trigger_positive_asserts

--- a/evals/chainlink-vrf-skill/rubrics/starter-kit.txt
+++ b/evals/chainlink-vrf-skill/rubrics/starter-kit.txt
@@ -1,0 +1,13 @@
+You are evaluating whether the response scaffolds the VRF Foundry starter-kit faithfully when the user asks for a working example, runnable project, or Foundry starter kit.
+
+A correct starter-kit response should:
+1. Scaffold a complete Foundry project rather than an isolated snippet — a VRF consumer contract, a deploy script, tests, and project config (`foundry.toml` / `remappings.txt`). It is correct to rely on the `VRFCoordinatorV2_5Mock` shipped with `@chainlink/contracts` for tests/local deploy rather than vendoring a custom mock.
+2. Use VRF v2.5 throughout: the consumer inherits `VRFConsumerBaseV2Plus`, requests randomness via the `VRFV2PlusClient.RandomWordsRequest` struct with `extraArgs`, uses a `uint256` subscription ID, and implements `fulfillRandomWords` with `calldata` random words. It must NOT use the legacy `VRFConsumerBaseV2` base, `uint64` subscription IDs, or positional `requestRandomWords` arguments.
+3. Provide install and run commands — installing `forge-std` and the Chainlink contracts dependency, then `forge test` (and the deploy `forge script` command).
+4. Default to Ethereum Sepolia VRF v2.5 (coordinator `0x9DdfaCa8183c41ad55329BdeeD9F6A8d53168B1B`, 500 gwei key hash) unless the user asks for another chain, and tell the user to verify coordinator addresses and key hashes against the official Chainlink docs. It should note that a funded subscription (created at vrf.chain.link) is required and the consumer must be added to it.
+5. Keep the template's Foundry layout and `VRFConsumerV2Plus` contract name unless the user asks for a different framework, and note that the example code is unaudited and should be reviewed before production use.
+
+Score:
+- 1.0: Faithful, complete starter-kit scaffold using VRF v2.5 with run/verify guidance (PASS)
+- 0.5: Partial scaffold — missing some template files, commands, or v2.5 details (FAIL)
+- 0.0: Returns only a snippet, invents unrelated scaffolding, or emits legacy V2 patterns (FAIL)


### PR DESCRIPTION
## Description

  Adds a Chainlink VRF Foundry starter-kit template to `chainlink-vrf-skill`, mirroring the
  existing data-feeds starter kit, so the skill can hand users a complete, runnable project
  instead of an isolated snippet.

  **Template** (`chainlink-vrf-skill/templates/starter-kit/`):
  - `src/VRFConsumerV2Plus.sol` — a **VRF v2.5** subscription consumer (`VRFConsumerBaseV2Plus`,
  `VRFV2PlusClient.RandomWordsRequest` struct with `extraArgs`, `uint256` subscription ID,
  `calldata` callback). Based on the Chainlink Foundry Starter Kit `VRFConsumerV2.sol` pattern but
  upgraded to v2.5 — the legacy V2 source the skill explicitly refuses to emit would not compile
  against current coordinators.
  - `test/VRFConsumerV2Plus.t.sol` — 4 tests against the `VRFCoordinatorV2_5Mock` shipped with
  `@chainlink/contracts` (no vendored mock).
  - `script/VRFConsumerV2Plus.s.sol` — defaults to Sepolia (live coordinator + 500 gwei key hash,
  subscription ID via `SUBSCRIPTION_ID` env); on local chains it deploys and funds a mock and
  wires the consumer end-to-end.
  - `foundry.toml`, `remappings.txt`, `.gitignore`, and a `README.md` covering dependencies, v2.5
  essentials, default network, and run commands.
  - Dependency metadata includes OpenZeppelin v4.9.6, which `chainlink-evm@contracts-v1.5.0`
  imports transitively via versioned `@openzeppelin/contracts@4.9.6/...` paths — without it a
  fresh project fails to compile.

  **Skill** (`SKILL.md`): added progressive-disclosure and routing entries pointing
  project-level/Foundry-starter requests to the template.

  **Evals** (`evals/chainlink-vrf-skill/`): added a `starter-kit` rubric, two functional cases and
  one trigger-positive case, and the corresponding `promptfooconfig.yaml` entries and README
  updates (10 cases total, 9 smoke-tagged).

  Verified in a fresh project with the three documented dependencies installed: `forge test
  --offline` passes all 4 tests and `forge script ...DeployVRFConsumerV2Plus --offline` deploys
  successfully.

  ## Justification

  The VRF skill could generate consumer snippets but had no scaffolding path, so "give me a
  working VRF project I can build and test" requests produced ad-hoc, often non-compiling
  projects. A vetted, version-correct starter kit gives users a known-good v2.5 baseline that
  builds and tests locally on the first try, keeps generated projects aligned with the skill's
  safety defaults (v2.5-only, no invented addresses), and brings VRF to parity with the data-feeds
  skill. The included evals guard the behavior against regressions.