### PR TITLE
Instruct CRE skill agent to use JSON output flags on CLI commands

### DIFF
--- a/chainlink-cre-skill/SKILL.md
+++ b/chainlink-cre-skill/SKILL.md
@@ -6,7 +6,7 @@ compatibility: Designed for AI agents that implement https://agentskills.io/spec
 allowed-tools: Read WebFetch Write Edit Bash
 metadata:
   purpose: CRE developer onboarding, assistance and reference
-  version: "0.0.12"
+  version: "0.0.13"
 ---
 
 # Chainlink CRE Skill

--- a/chainlink-cre-skill/references/cli-reference.md
+++ b/chainlink-cre-skill/references/cli-reference.md
@@ -18,6 +18,12 @@ When running CRE CLI commands from an automated agent or script, always provide 
 Key rules:
 - **Always pass `--target`** on every `cre workflow` and `cre secrets` command. Omitting it triggers a "Select a target" interactive prompt.
 - **Always pass `--non-interactive`** with `cre init` plus the required flags (`--project-name`, `--template`). Without `--non-interactive`, the command prompts for input.
+- **Request JSON output whenever the command supports it** so you can parse results reliably instead of scraping human-formatted text. The flag differs by command:
+  - `cre templates list --json`
+  - `cre workflow list --output json`
+  - `cre workflow supported-chains --output json`
+
+  These are the only commands that currently support JSON output. Note the flag style differs: `templates list` uses the boolean `--json`, while `workflow list` and `workflow supported-chains` use `--output json`. Do not pass `--json` to commands that don't list it (it will error).
 
 ## Global Flags
 
@@ -212,12 +218,41 @@ List all workflows associated with the current account.
 cre workflow list --target <target-name>
 ```
 
+| Flag | Description |
+|------|-------------|
+| `--output json` | Print the workflow list as a JSON array to stdout. Use this when running as an agent so the output can be parsed. |
+| `--include-deleted` | Include workflows in `DELETED` status |
+
+Agent example (machine-readable output):
+
+```bash
+cre workflow list --target <target-name> --output json
+```
+
 ### `cre workflow show`
 
 Show details of a specific deployed workflow.
 
 ```bash
 cre workflow show <workflow-dir> --target <target-name>
+```
+
+### `cre workflow supported-chains`
+
+List chains and mock forwarder addresses available for your tenant.
+
+```bash
+cre workflow supported-chains --target <target-name>
+```
+
+| Flag | Description |
+|------|-------------|
+| `--output json` | Print the supported chains as a JSON array to stdout. Use this when running as an agent so the output can be parsed. |
+
+Agent example (machine-readable output):
+
+```bash
+cre workflow supported-chains --target <target-name> --output json
 ```
 
 ## Account Commands
@@ -282,6 +317,43 @@ List secret namespaces for the current account.
 
 ```bash
 cre secrets list --target <target-name>
+```
+
+## Templates Commands
+
+### `cre templates list`
+
+List all templates available from the configured repository sources. These can be installed with `cre init`.
+
+```bash
+cre templates list
+```
+
+| Flag | Description |
+|------|-------------|
+| `--json` | Output the template list as JSON. Use this when running as an agent so the output can be parsed. |
+| `--refresh` | Bypass the cache and fetch fresh data from the source repositories |
+
+Agent example (machine-readable output):
+
+```bash
+cre templates list --json
+```
+
+### `cre templates add`
+
+Add a template repository source.
+
+```bash
+cre templates add <repository-source>
+```
+
+### `cre templates remove`
+
+Remove a template repository source.
+
+```bash
+cre templates remove <repository-source>
 ```
 
 ## Utility Commands

--- a/chainlink-cre-skill/references/project-scaffolding.md
+++ b/chainlink-cre-skill/references/project-scaffolding.md
@@ -33,7 +33,7 @@ Built-in templates (available offline, no GitHub fetch needed):
 - `hello-world-go` - Go hello world with cron trigger
 - `hello-world-ts` - TypeScript hello world with cron trigger
 
-Run `cre templates list` to see all available templates including those from GitHub.
+Run `cre templates list` to see all available templates including those from GitHub. When running as an agent, add the `--json` flag (`cre templates list --json`) to receive machine-readable output for reliable parsing.
 
 #### TypeScript project:
 


### PR DESCRIPTION
  ## Description

  Updates `chainlink-cre-skill` so the agent requests machine-readable JSON output from CRE CLI
  commands that support it, instead of parsing human-formatted text.

  After auditing every `cre` subcommand's help output locally, exactly three commands support JSON
  output, via two different flag styles:

  | Command | Flag |
  |---|---|
  | `cre templates list` | `--json` (boolean) |
  | `cre workflow list` | `--output json` (string) |
  | `cre workflow supported-chains` | `--output json` (string) |

  Changes (`chainlink-cre-skill`, version `0.0.12` → `0.0.13`):

  - **`references/cli-reference.md`**
    - Added a JSON-output rule to the "Non-Interactive Usage" section listing all three commands
  with their exact (differing) flag styles, and warning not to pass `--json` to commands that
  don't support it.
    - Added `--output json` documentation and an agent example to `cre workflow list`.
    - Documented the previously-missing `cre workflow supported-chains` command, including its
  `--output json` flag.
    - Added a new **Templates Commands** section documenting `cre templates list` (with `--json`),
  `cre templates add`, and `cre templates remove`, which were not previously documented.
  - **`references/project-scaffolding.md`**
    - Updated the `cre templates list` reference to instruct the agent to add `--json` for
  machine-readable output.

  ## Justification

  The original skill referenced `cre templates list` without telling the agent it could emit JSON,
  and didn't document `cre workflow supported-chains` or the JSON capabilities of `cre workflow
  list` at all. Without this guidance, the agent scrapes human-formatted tables, which is brittle
  and error-prone. Pointing it at the JSON flags makes parsing reliable. Documenting the two
  distinct flag styles (`--json` vs `--output json`) prevents the agent from passing `--json` to
  commands that would reject it.