### PR TITLE
fix(evals): load declared skill references

### DIFF
--- a/.github/scripts/validate-promptfoo-configs.rb
+++ b/.github/scripts/validate-promptfoo-configs.rb
@@ -1,0 +1,97 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "pathname"
+require "psych"
+
+ROOT = Pathname.new(__dir__).join("..", "..").realpath.freeze
+SKILL_IDS = %w[
+  chainlink-ccip-skill
+  chainlink-cre-skill
+  chainlink-data-feeds-skill
+  chainlink-data-streams-skill
+  chainlink-vrf-skill
+  chainlink-ace-skill
+].freeze
+HELPER_REQUIRE = 'require("../../shared/with-skill-prompt")'.freeze
+
+abort "Usage: ruby .github/scripts/validate-promptfoo-configs.rb references" unless ARGV == ["references"]
+
+failures = []
+
+def report(failures, context, message)
+  failures << "#{context}: #{message}"
+end
+
+def validate_prompt_script(root, skill_id, failures)
+  prompt_path = root.join("evals", skill_id, "prompts", "with-skill.js")
+  context = prompt_path.relative_path_from(root)
+  source = prompt_path.read
+
+  report(failures, context, "must use the shared with-skill prompt helper") unless source.include?(HELPER_REQUIRE)
+  report(failures, context, "must not read files directly") if source.match?(/readFile(?:Sync)?\s*\(/)
+end
+
+def validate_reference_path(root, skill_root, reference_file, context, failures)
+  unless reference_file.is_a?(String) && !reference_file.empty?
+    report(failures, context, "reference_files entries must be non-empty strings")
+    return
+  end
+
+  candidate = Pathname.new(reference_file)
+  if candidate.absolute?
+    report(failures, context, "reference path must be relative: #{reference_file.inspect}")
+    return
+  end
+
+  resolved = skill_root.join(candidate).cleanpath
+  unless resolved.to_s.start_with?("#{skill_root}/")
+    report(failures, context, "reference path escapes skill directory: #{reference_file.inspect}")
+    return
+  end
+
+  unless resolved.file?
+    report(failures, context, "reference file does not exist: #{reference_file.inspect}")
+    return
+  end
+
+  canonical = resolved.realpath
+  unless canonical.to_s.start_with?("#{skill_root}/")
+    report(failures, context, "reference path escapes skill directory through a symlink: #{reference_file.inspect}")
+  end
+end
+
+SKILL_IDS.each do |skill_id|
+  config_path = ROOT.join("evals", skill_id, "promptfooconfig.yaml")
+  skill_root = ROOT.join(skill_id).realpath
+  config = Psych.safe_load(config_path.read, aliases: true)
+  tests = config.fetch("tests")
+
+  validate_prompt_script(ROOT, skill_id, failures)
+
+  tests.each_with_index do |test, index|
+    context = "#{config_path.relative_path_from(ROOT)} test #{index + 1} (#{test.fetch("description", "unnamed")})"
+    vars = test["vars"]
+    unless vars.is_a?(Hash)
+      report(failures, context, "must define vars")
+      next
+    end
+
+    unless vars.key?("reference_files") && vars["reference_files"].is_a?(Array)
+      report(failures, context, "vars.reference_files must be an array")
+      next
+    end
+
+    references = vars["reference_files"]
+    report(failures, context, "vars.reference_files must not contain duplicate paths") unless references.uniq.length == references.length
+    references.each { |reference_file| validate_reference_path(ROOT, skill_root, reference_file, context, failures) }
+  end
+end
+
+if failures.empty?
+  puts "Promptfoo reference metadata is valid."
+  exit 0
+end
+
+warn failures.join("\n")
+exit 1

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ Thumbs.db
 # IDE / editor
 .idea/
 .vscode/
+.omp/
 *.swp
 *.swo
 *~

--- a/evals/chainlink-ace-skill/promptfooconfig.yaml
+++ b/evals/chainlink-ace-skill/promptfooconfig.yaml
@@ -51,6 +51,9 @@ tests:
       case_file: cases/functional/repo-scope-01.txt
       workflow: repo-scope
       requires_live_source: "no"
+      reference_files:
+        - references/getting-started-and-scope.md
+        - references/onchain-contracts.md
     metadata:
       workflow: repo-scope
       category: functional
@@ -61,6 +64,9 @@ tests:
       case_file: cases/functional/platform-beta-mainnet-01.txt
       workflow: platform-beta
       requires_live_source: "yes"
+      reference_files:
+        - references/platform-and-beta.md
+        - references/official-sources.md
     metadata:
       workflow: platform-beta
       category: functional
@@ -71,6 +77,9 @@ tests:
       case_file: cases/functional/reporting-api-audit-01.txt
       workflow: platform-reporting
       requires_live_source: "yes"
+      reference_files:
+        - references/platform-and-beta.md
+        - references/official-sources.md
     metadata:
       workflow: platform-reporting
       category: functional
@@ -81,6 +90,9 @@ tests:
       case_file: cases/functional/coordinator-vs-reporting-01.txt
       workflow: platform-apis
       requires_live_source: "yes"
+      reference_files:
+        - references/platform-and-beta.md
+        - references/official-sources.md
     metadata:
       workflow: platform-apis
       category: functional
@@ -91,6 +103,10 @@ tests:
       case_file: cases/functional/platform-credential-mode-01.txt
       workflow: platform-identity
       requires_live_source: "yes"
+      reference_files:
+        - references/platform-and-beta.md
+        - references/cross-chain-identity.md
+        - references/official-sources.md
     metadata:
       workflow: platform-identity
       category: functional
@@ -101,6 +117,9 @@ tests:
       case_file: cases/functional/foundry-platform-visibility-01.txt
       workflow: platform-visibility
       requires_live_source: "yes"
+      reference_files:
+        - references/platform-and-beta.md
+        - references/official-sources.md
     metadata:
       workflow: platform-visibility
       category: functional
@@ -111,6 +130,9 @@ tests:
       case_file: cases/functional/onchain-contracts-01.txt
       workflow: onchain-contracts
       requires_live_source: "no"
+      reference_files:
+        - references/onchain-contracts.md
+        - references/policy-management.md
     metadata:
       workflow: onchain-contracts
       category: functional
@@ -121,6 +143,10 @@ tests:
       case_file: cases/functional/upgrade-01.txt
       workflow: upgrade
       requires_live_source: "no"
+      reference_files:
+        - references/onchain-contracts.md
+        - references/policy-management.md
+        - references/contracts-and-source.md
     metadata:
       workflow: upgrade
       category: functional
@@ -131,6 +157,10 @@ tests:
       case_file: cases/functional/policy-chain-01.txt
       workflow: policy-management
       requires_live_source: "no"
+      reference_files:
+        - references/policy-management.md
+        - references/policy-library.md
+        - references/cross-chain-identity.md
     metadata:
       workflow: policy-management
       category: functional
@@ -141,6 +171,8 @@ tests:
       case_file: cases/functional/cross-chain-identity-01.txt
       workflow: cross-chain-identity
       requires_live_source: "no"
+      reference_files:
+        - references/cross-chain-identity.md
     metadata:
       workflow: cross-chain-identity
       category: functional
@@ -151,6 +183,9 @@ tests:
       case_file: cases/functional/secure-mint-01.txt
       workflow: policy-library
       requires_live_source: "yes"
+      reference_files:
+        - references/policy-library.md
+        - references/official-sources.md
     metadata:
       workflow: policy-library
       category: functional
@@ -161,6 +196,9 @@ tests:
       case_file: cases/functional/token-examples-01.txt
       workflow: token-examples
       requires_live_source: "no"
+      reference_files:
+        - references/contracts-and-source.md
+        - references/onchain-contracts.md
     metadata:
       workflow: token-examples
       category: functional
@@ -171,6 +209,9 @@ tests:
       case_file: cases/trigger-positive/ace-overview-01.txt
       workflow: repo-scope
       expected_trigger: "yes"
+      reference_files:
+        - references/getting-started-and-scope.md
+        - references/onchain-contracts.md
     metadata:
       workflow: repo-scope
       category: trigger-positive
@@ -181,6 +222,9 @@ tests:
       case_file: cases/trigger-positive/ace-platform-01.txt
       workflow: platform-beta
       expected_trigger: "yes"
+      reference_files:
+        - references/platform-and-beta.md
+        - references/official-sources.md
     metadata:
       workflow: platform-beta
       category: trigger-positive
@@ -191,6 +235,8 @@ tests:
       case_file: cases/trigger-positive/policy-engine-01.txt
       workflow: policy-management
       expected_trigger: "yes"
+      reference_files:
+        - references/policy-management.md
     metadata:
       workflow: policy-management
       category: trigger-positive
@@ -201,6 +247,8 @@ tests:
       case_file: cases/trigger-positive/ccid-01.txt
       workflow: cross-chain-identity
       expected_trigger: "yes"
+      reference_files:
+        - references/cross-chain-identity.md
     metadata:
       workflow: cross-chain-identity
       category: trigger-positive
@@ -211,6 +259,10 @@ tests:
       case_file: cases/trigger-positive/chainlink-ace-repo-01.txt
       workflow: onchain-contracts
       expected_trigger: "yes"
+      reference_files:
+        - references/onchain-contracts.md
+        - references/policy-management.md
+        - references/contracts-and-source.md
     metadata:
       workflow: onchain-contracts
       category: trigger-positive
@@ -221,6 +273,7 @@ tests:
       case_file: cases/trigger-negative/ccip-01.txt
       workflow: none
       expected_trigger: "no"
+      reference_files: []
     metadata:
       workflow: none
       category: trigger-negative
@@ -231,6 +284,7 @@ tests:
       case_file: cases/trigger-negative/cre-01.txt
       workflow: none
       expected_trigger: "no"
+      reference_files: []
     metadata:
       workflow: none
       category: trigger-negative
@@ -241,6 +295,7 @@ tests:
       case_file: cases/trigger-negative/data-feeds-01.txt
       workflow: none
       expected_trigger: "no"
+      reference_files: []
     metadata:
       workflow: none
       category: trigger-negative
@@ -251,6 +306,7 @@ tests:
       case_file: cases/trigger-negative/generic-solidity-01.txt
       workflow: none
       expected_trigger: "no"
+      reference_files: []
     metadata:
       workflow: none
       category: trigger-negative

--- a/evals/chainlink-ace-skill/prompts/with-skill.js
+++ b/evals/chainlink-ace-skill/prompts/with-skill.js
@@ -1,15 +1,10 @@
-const fs = require("fs");
 const path = require("path");
+const withSkillPrompt = require("../../shared/with-skill-prompt");
 
 module.exports = function ({ vars }) {
-  const caseFile = vars.case_file;
-  const content = fs.readFileSync(path.resolve(__dirname, "..", caseFile), "utf8").trim();
-
-  const skillPath = path.resolve(__dirname, "..", "..", "..", "chainlink-ace-skill", "SKILL.md");
-  const skillContent = fs.readFileSync(skillPath, "utf8").trim();
-
-  return [
-    { role: "system", content: skillContent },
-    { role: "user", content: content },
-  ];
+  return withSkillPrompt({
+    skillId: "chainlink-ace-skill",
+    evalDir: path.resolve(__dirname, ".."),
+    vars,
+  });
 };

--- a/evals/chainlink-ccip-skill/promptfooconfig.yaml
+++ b/evals/chainlink-ccip-skill/promptfooconfig.yaml
@@ -101,6 +101,9 @@ tests:
       expected_trigger: "yes"
       requires_live_source: "yes"
       requires_approval: "yes"
+      reference_files:
+        - references/ccip-cct.md
+        - references/official-sources.md
     metadata:
       workflow: cct
       category: functional
@@ -114,6 +117,9 @@ tests:
       expected_trigger: "yes"
       requires_live_source: "yes"
       requires_approval: "yes"
+      reference_files:
+        - references/ccip-cct.md
+        - references/official-sources.md
     metadata:
       workflow: cct
       category: functional
@@ -126,6 +132,9 @@ tests:
       expected_trigger: "yes"
       requires_live_source: "yes"
       requires_approval: "yes"
+      reference_files:
+        - references/ccip-cct.md
+        - references/official-sources.md
     metadata:
       workflow: cct
       category: functional
@@ -138,6 +147,10 @@ tests:
       expected_trigger: "yes"
       requires_live_source: "yes"
       requires_approval: "yes"
+      reference_files:
+        - references/ccip-cct.md
+        - references/ccip-discovery.md
+        - references/official-sources.md
     metadata:
       workflow: cct
       category: functional
@@ -150,6 +163,9 @@ tests:
       expected_trigger: "yes"
       requires_live_source: "no"
       requires_approval: "no"
+      reference_files:
+        - references/chainlink-local.md
+        - references/ccip-solidity-examples.md
     metadata:
       workflow: chainlink-local
       category: functional
@@ -163,6 +179,9 @@ tests:
       expected_trigger: "yes"
       requires_live_source: "no"
       requires_approval: "no"
+      reference_files:
+        - references/chainlink-local.md
+        - references/ccip-solidity-examples.md
     metadata:
       workflow: chainlink-local
       category: functional
@@ -175,6 +194,9 @@ tests:
       expected_trigger: "yes"
       requires_live_source: "no"
       requires_approval: "no"
+      reference_files:
+        - references/chainlink-local.md
+        - references/ccip-solidity-examples.md
     metadata:
       workflow: chainlink-local
       category: functional
@@ -187,6 +209,9 @@ tests:
       expected_trigger: "yes"
       requires_live_source: "no"
       requires_approval: "no"
+      reference_files:
+        - references/chainlink-local.md
+        - references/ccip-solidity-examples.md
     metadata:
       workflow: chainlink-local
       category: functional
@@ -199,6 +224,9 @@ tests:
       expected_trigger: "yes"
       requires_live_source: "yes"
       requires_approval: "no"
+      reference_files:
+        - references/chainlink-local.md
+        - references/official-sources.md
     metadata:
       workflow: chainlink-local
       category: functional
@@ -211,6 +239,9 @@ tests:
       expected_trigger: "yes"
       requires_live_source: "no"
       requires_approval: "no"
+      reference_files:
+        - references/ccip-contracts.md
+        - references/ccip-solidity-examples.md
     metadata:
       workflow: contract-first
       category: functional
@@ -224,6 +255,9 @@ tests:
       expected_trigger: "yes"
       requires_live_source: "no"
       requires_approval: "no"
+      reference_files:
+        - references/ccip-contracts.md
+        - references/ccip-solidity-examples.md
     metadata:
       workflow: contract-first
       category: functional
@@ -236,6 +270,8 @@ tests:
       expected_trigger: "yes"
       requires_live_source: "no"
       requires_approval: "no"
+      reference_files:
+        - references/ccip-contracts.md
     metadata:
       workflow: contract-first
       category: functional
@@ -248,6 +284,9 @@ tests:
       expected_trigger: "yes"
       requires_live_source: "no"
       requires_approval: "no"
+      reference_files:
+        - references/ccip-contracts.md
+        - references/ccip-solidity-examples.md
     metadata:
       workflow: contract-first
       category: functional
@@ -260,6 +299,8 @@ tests:
       expected_trigger: "yes"
       requires_live_source: "no"
       requires_approval: "no"
+      reference_files:
+        - references/ccip-contracts.md
     metadata:
       workflow: contract-first
       category: functional
@@ -272,6 +313,9 @@ tests:
       expected_trigger: "yes"
       requires_live_source: "no"
       requires_approval: "no"
+      reference_files:
+        - references/ccip-contracts.md
+        - references/ccip-solidity-examples.md
     metadata:
       workflow: contract-first
       category: functional
@@ -284,6 +328,9 @@ tests:
       expected_trigger: "yes"
       requires_live_source: "yes"
       requires_approval: "no"
+      reference_files:
+        - references/ccip-discovery.md
+        - references/official-sources.md
     metadata:
       workflow: discovery
       category: functional
@@ -297,6 +344,9 @@ tests:
       expected_trigger: "yes"
       requires_live_source: "yes"
       requires_approval: "no"
+      reference_files:
+        - references/ccip-discovery.md
+        - references/official-sources.md
     metadata:
       workflow: discovery
       category: functional
@@ -309,6 +359,9 @@ tests:
       expected_trigger: "yes"
       requires_live_source: "yes"
       requires_approval: "no"
+      reference_files:
+        - references/ccip-discovery.md
+        - references/official-sources.md
     metadata:
       workflow: discovery
       category: functional
@@ -321,6 +374,10 @@ tests:
       expected_trigger: "yes"
       requires_live_source: "yes"
       requires_approval: "no"
+      reference_files:
+        - references/ccip-discovery.md
+        - references/ccip-monitoring.md
+        - references/official-sources.md
     metadata:
       workflow: discovery
       category: functional
@@ -333,6 +390,9 @@ tests:
       expected_trigger: "yes"
       requires_live_source: "yes"
       requires_approval: "no"
+      reference_files:
+        - references/ccip-monitoring.md
+        - references/official-sources.md
     metadata:
       workflow: monitoring
       category: functional
@@ -346,6 +406,9 @@ tests:
       expected_trigger: "yes"
       requires_live_source: "yes"
       requires_approval: "no"
+      reference_files:
+        - references/ccip-monitoring.md
+        - references/official-sources.md
     metadata:
       workflow: monitoring
       category: functional
@@ -358,6 +421,9 @@ tests:
       expected_trigger: "yes"
       requires_live_source: "yes"
       requires_approval: "no"
+      reference_files:
+        - references/ccip-monitoring.md
+        - references/official-sources.md
     metadata:
       workflow: monitoring
       category: functional
@@ -370,6 +436,10 @@ tests:
       expected_trigger: "yes"
       requires_live_source: "yes"
       requires_approval: "no"
+      reference_files:
+        - references/ccip-monitoring.md
+        - references/ccip-discovery.md
+        - references/official-sources.md
     metadata:
       workflow: monitoring
       category: functional
@@ -382,6 +452,9 @@ tests:
       expected_trigger: "yes"
       requires_live_source: "yes"
       requires_approval: "yes"
+      reference_files:
+        - references/ccip-tools.md
+        - references/official-sources.md
     metadata:
       workflow: tool-first
       category: functional
@@ -395,6 +468,9 @@ tests:
       expected_trigger: "yes"
       requires_live_source: "yes"
       requires_approval: "yes"
+      reference_files:
+        - references/ccip-tools.md
+        - references/official-sources.md
     metadata:
       workflow: tool-first
       category: functional
@@ -407,6 +483,10 @@ tests:
       expected_trigger: "yes"
       requires_live_source: "yes"
       requires_approval: "yes"
+      reference_files:
+        - references/ccip-tools.md
+        - references/ccip-discovery.md
+        - references/official-sources.md
     metadata:
       workflow: tool-first
       category: functional
@@ -419,6 +499,9 @@ tests:
       expected_trigger: "yes"
       requires_live_source: "yes"
       requires_approval: "yes"
+      reference_files:
+        - references/ccip-tools.md
+        - references/official-sources.md
     metadata:
       workflow: tool-first
       category: functional
@@ -431,6 +514,7 @@ tests:
       expected_trigger: "no"
       requires_live_source: "yes"
       requires_approval: "yes"
+      reference_files: []
     metadata:
       workflow: cct
       category: trigger-negative
@@ -444,6 +528,7 @@ tests:
       expected_trigger: "no"
       requires_live_source: "yes"
       requires_approval: "yes"
+      reference_files: []
     metadata:
       workflow: cct
       category: trigger-negative
@@ -456,6 +541,7 @@ tests:
       expected_trigger: "no"
       requires_live_source: "no"
       requires_approval: "no"
+      reference_files: []
     metadata:
       workflow: chainlink-local
       category: trigger-negative
@@ -468,6 +554,7 @@ tests:
       expected_trigger: "no"
       requires_live_source: "no"
       requires_approval: "no"
+      reference_files: []
     metadata:
       workflow: chainlink-local
       category: trigger-negative
@@ -480,6 +567,7 @@ tests:
       expected_trigger: "no"
       requires_live_source: "no"
       requires_approval: "no"
+      reference_files: []
     metadata:
       workflow: contract-first
       category: trigger-negative
@@ -492,6 +580,7 @@ tests:
       expected_trigger: "no"
       requires_live_source: "no"
       requires_approval: "no"
+      reference_files: []
     metadata:
       workflow: contract-first
       category: trigger-negative
@@ -504,6 +593,7 @@ tests:
       expected_trigger: "no"
       requires_live_source: "yes"
       requires_approval: "no"
+      reference_files: []
     metadata:
       workflow: discovery
       category: trigger-negative
@@ -516,6 +606,7 @@ tests:
       expected_trigger: "no"
       requires_live_source: "yes"
       requires_approval: "no"
+      reference_files: []
     metadata:
       workflow: discovery
       category: trigger-negative
@@ -528,6 +619,7 @@ tests:
       expected_trigger: "no"
       requires_live_source: "yes"
       requires_approval: "no"
+      reference_files: []
     metadata:
       workflow: monitoring
       category: trigger-negative
@@ -540,6 +632,7 @@ tests:
       expected_trigger: "no"
       requires_live_source: "yes"
       requires_approval: "no"
+      reference_files: []
     metadata:
       workflow: monitoring
       category: trigger-negative
@@ -552,6 +645,7 @@ tests:
       expected_trigger: "no"
       requires_live_source: "yes"
       requires_approval: "yes"
+      reference_files: []
     metadata:
       workflow: tool-first
       category: trigger-negative
@@ -564,6 +658,7 @@ tests:
       expected_trigger: "no"
       requires_live_source: "yes"
       requires_approval: "yes"
+      reference_files: []
     metadata:
       workflow: tool-first
       category: trigger-negative
@@ -576,6 +671,9 @@ tests:
       expected_trigger: "yes"
       requires_live_source: "yes"
       requires_approval: "yes"
+      reference_files:
+        - references/ccip-cct.md
+        - references/official-sources.md
     metadata:
       workflow: cct
       category: trigger-positive
@@ -589,6 +687,9 @@ tests:
       expected_trigger: "yes"
       requires_live_source: "yes"
       requires_approval: "yes"
+      reference_files:
+        - references/ccip-cct.md
+        - references/official-sources.md
     metadata:
       workflow: cct
       category: trigger-positive
@@ -601,6 +702,9 @@ tests:
       expected_trigger: "yes"
       requires_live_source: "yes"
       requires_approval: "yes"
+      reference_files:
+        - references/ccip-cct.md
+        - references/official-sources.md
     metadata:
       workflow: cct
       category: trigger-positive
@@ -613,6 +717,9 @@ tests:
       expected_trigger: "yes"
       requires_live_source: "no"
       requires_approval: "no"
+      reference_files:
+        - references/chainlink-local.md
+        - references/ccip-solidity-examples.md
     metadata:
       workflow: chainlink-local
       category: trigger-positive
@@ -625,6 +732,8 @@ tests:
       expected_trigger: "yes"
       requires_live_source: "no"
       requires_approval: "no"
+      reference_files:
+        - references/chainlink-local.md
     metadata:
       workflow: chainlink-local
       category: trigger-positive
@@ -637,6 +746,8 @@ tests:
       expected_trigger: "yes"
       requires_live_source: "no"
       requires_approval: "no"
+      reference_files:
+        - references/chainlink-local.md
     metadata:
       workflow: chainlink-local
       category: trigger-positive
@@ -649,6 +760,9 @@ tests:
       expected_trigger: "yes"
       requires_live_source: "no"
       requires_approval: "no"
+      reference_files:
+        - references/ccip-contracts.md
+        - references/ccip-solidity-examples.md
     metadata:
       workflow: contract-first
       category: trigger-positive
@@ -662,6 +776,9 @@ tests:
       expected_trigger: "yes"
       requires_live_source: "no"
       requires_approval: "no"
+      reference_files:
+        - references/ccip-contracts.md
+        - references/ccip-solidity-examples.md
     metadata:
       workflow: contract-first
       category: trigger-positive
@@ -674,6 +791,8 @@ tests:
       expected_trigger: "yes"
       requires_live_source: "no"
       requires_approval: "no"
+      reference_files:
+        - references/ccip-contracts.md
     metadata:
       workflow: contract-first
       category: trigger-positive
@@ -686,6 +805,9 @@ tests:
       expected_trigger: "yes"
       requires_live_source: "yes"
       requires_approval: "no"
+      reference_files:
+        - references/ccip-discovery.md
+        - references/official-sources.md
     metadata:
       workflow: discovery
       category: trigger-positive
@@ -698,6 +820,9 @@ tests:
       expected_trigger: "yes"
       requires_live_source: "yes"
       requires_approval: "no"
+      reference_files:
+        - references/ccip-discovery.md
+        - references/official-sources.md
     metadata:
       workflow: discovery
       category: trigger-positive
@@ -710,6 +835,9 @@ tests:
       expected_trigger: "yes"
       requires_live_source: "yes"
       requires_approval: "no"
+      reference_files:
+        - references/ccip-discovery.md
+        - references/official-sources.md
     metadata:
       workflow: discovery
       category: trigger-positive
@@ -722,6 +850,9 @@ tests:
       expected_trigger: "yes"
       requires_live_source: "yes"
       requires_approval: "no"
+      reference_files:
+        - references/ccip-monitoring.md
+        - references/official-sources.md
     metadata:
       workflow: monitoring
       category: trigger-positive
@@ -735,6 +866,9 @@ tests:
       expected_trigger: "yes"
       requires_live_source: "yes"
       requires_approval: "no"
+      reference_files:
+        - references/ccip-monitoring.md
+        - references/official-sources.md
     metadata:
       workflow: monitoring
       category: trigger-positive
@@ -747,6 +881,9 @@ tests:
       expected_trigger: "yes"
       requires_live_source: "yes"
       requires_approval: "no"
+      reference_files:
+        - references/ccip-monitoring.md
+        - references/official-sources.md
     metadata:
       workflow: monitoring
       category: trigger-positive
@@ -759,6 +896,9 @@ tests:
       expected_trigger: "yes"
       requires_live_source: "yes"
       requires_approval: "yes"
+      reference_files:
+        - references/ccip-tools.md
+        - references/official-sources.md
     metadata:
       workflow: tool-first
       category: trigger-positive
@@ -771,6 +911,9 @@ tests:
       expected_trigger: "yes"
       requires_live_source: "yes"
       requires_approval: "yes"
+      reference_files:
+        - references/ccip-tools.md
+        - references/official-sources.md
     metadata:
       workflow: tool-first
       category: trigger-positive
@@ -783,6 +926,9 @@ tests:
       expected_trigger: "yes"
       requires_live_source: "yes"
       requires_approval: "yes"
+      reference_files:
+        - references/ccip-tools.md
+        - references/official-sources.md
     metadata:
       workflow: tool-first
       category: trigger-positive
@@ -796,6 +942,10 @@ tests:
       expected_trigger: "yes"
       requires_live_source: "yes"
       requires_approval: "yes"
+      reference_files:
+        - references/ccip-tools.md
+        - references/ccip-discovery.md
+        - references/official-sources.md
     metadata:
       workflow: tool-first
       category: functional
@@ -809,6 +959,9 @@ tests:
       expected_trigger: "yes"
       requires_live_source: "yes"
       requires_approval: "yes"
+      reference_files:
+        - references/ccip-tools.md
+        - references/official-sources.md
     metadata:
       workflow: tool-first
       category: functional
@@ -821,6 +974,9 @@ tests:
       expected_trigger: "yes"
       requires_live_source: "no"
       requires_approval: "no"
+      reference_files:
+        - references/ccip-contracts.md
+        - references/ccip-solidity-examples.md
     metadata:
       workflow: contract-first
       category: functional
@@ -833,6 +989,9 @@ tests:
       expected_trigger: "yes"
       requires_live_source: "no"
       requires_approval: "no"
+      reference_files:
+        - references/ccip-contracts.md
+        - references/ccip-solidity-examples.md
     metadata:
       workflow: contract-first
       category: functional
@@ -845,6 +1004,9 @@ tests:
       expected_trigger: "yes"
       requires_live_source: "yes"
       requires_approval: "no"
+      reference_files:
+        - references/ccip-monitoring.md
+        - references/official-sources.md
     metadata:
       workflow: monitoring
       category: functional
@@ -857,6 +1019,9 @@ tests:
       expected_trigger: "yes"
       requires_live_source: "yes"
       requires_approval: "no"
+      reference_files:
+        - references/ccip-discovery.md
+        - references/official-sources.md
     metadata:
       workflow: discovery
       category: functional
@@ -869,6 +1034,9 @@ tests:
       expected_trigger: "yes"
       requires_live_source: "no"
       requires_approval: "no"
+      reference_files:
+        - references/ccip-contracts.md
+        - references/ccip-solidity-examples.md
     metadata:
       workflow: contract-first
       category: functional
@@ -882,6 +1050,7 @@ tests:
       expected_trigger: "no"
       requires_live_source: "no"
       requires_approval: "no"
+      reference_files: []
     metadata:
       workflow: tool-first
       category: trigger-negative
@@ -895,6 +1064,7 @@ tests:
       expected_trigger: "no"
       requires_live_source: "no"
       requires_approval: "no"
+      reference_files: []
     metadata:
       workflow: tool-first
       category: trigger-negative
@@ -907,6 +1077,7 @@ tests:
       expected_trigger: "no"
       requires_live_source: "no"
       requires_approval: "no"
+      reference_files: []
     metadata:
       workflow: contract-first
       category: trigger-negative
@@ -919,6 +1090,7 @@ tests:
       expected_trigger: "no"
       requires_live_source: "no"
       requires_approval: "no"
+      reference_files: []
     metadata:
       workflow: tool-first
       category: trigger-negative
@@ -931,6 +1103,7 @@ tests:
       expected_trigger: "no"
       requires_live_source: "no"
       requires_approval: "no"
+      reference_files: []
     metadata:
       workflow: tool-first
       category: trigger-negative

--- a/evals/chainlink-ccip-skill/prompts/with-skill.js
+++ b/evals/chainlink-ccip-skill/prompts/with-skill.js
@@ -1,15 +1,10 @@
-const fs = require("fs");
 const path = require("path");
+const withSkillPrompt = require("../../shared/with-skill-prompt");
 
 module.exports = function ({ vars }) {
-  const caseFile = vars.case_file;
-  const content = fs.readFileSync(path.resolve(__dirname, "..", caseFile), "utf8").trim();
-
-  const skillPath = path.resolve(__dirname, "..", "..", "..", "chainlink-ccip-skill", "SKILL.md");
-  const skillContent = fs.readFileSync(skillPath, "utf8").trim();
-
-  return [
-    { role: "system", content: skillContent },
-    { role: "user", content: content },
-  ];
+  return withSkillPrompt({
+    skillId: "chainlink-ccip-skill",
+    evalDir: path.resolve(__dirname, ".."),
+    vars,
+  });
 };

--- a/evals/chainlink-cre-skill/promptfooconfig.yaml
+++ b/evals/chainlink-cre-skill/promptfooconfig.yaml
@@ -59,6 +59,12 @@ tests:
   # ── Functional: Workflow Generation ──────────────────────────────────
   - vars:
       case_file: cases/functional/workflow-generation-01.txt
+      reference_files:
+        - references/project-scaffolding.md
+        - references/triggers.md
+        - references/http-client.md
+        - references/evm-client.md
+        - references/workflow-patterns.md
       workflow: workflow-generation
       requires_live_source: "no"
     metadata:
@@ -69,18 +75,33 @@ tests:
 
   - vars:
       case_file: cases/functional/workflow-generation-02.txt
+      reference_files:
+        - references/project-scaffolding.md
+        - references/triggers.md
+        - references/evm-client.md
       workflow: workflow-generation
       requires_live_source: "no"
     assert: *functional_asserts
 
   - vars:
       case_file: cases/functional/workflow-generation-03.txt
+      reference_files:
+        - references/project-scaffolding.md
+        - references/workflow-patterns.md
+        - references/triggers.md
+        - references/evm-client.md
       workflow: workflow-generation
       requires_live_source: "no"
     assert: *functional_asserts
 
   - vars:
       case_file: cases/functional/workflow-generation-04.txt
+      reference_files:
+        - references/project-scaffolding.md
+        - references/triggers.md
+        - references/http-client.md
+        - references/evm-client.md
+        - references/workflow-patterns.md
       workflow: workflow-generation
       requires_live_source: "no"
     metadata:
@@ -91,6 +112,11 @@ tests:
 
   - vars:
       case_file: cases/functional/workflow-generation-05.txt
+      reference_files:
+        - references/project-scaffolding.md
+        - references/evm-client.md
+        - references/workflow-patterns.md
+        - references/simulation.md
       workflow: workflow-generation
       requires_live_source: "no"
     metadata:
@@ -102,12 +128,19 @@ tests:
   # ── Functional: Project Scaffolding ──────────────────────────────────
   - vars:
       case_file: cases/functional/project-scaffolding-01.txt
+      reference_files:
+        - references/project-scaffolding.md
+        - references/simulation.md
       workflow: project-scaffolding
       requires_live_source: "no"
     assert: *functional_asserts
 
   - vars:
       case_file: cases/functional/project-scaffolding-02.txt
+      reference_files:
+        - references/project-scaffolding.md
+        - references/triggers.md
+        - references/simulation.md
       workflow: project-scaffolding
       requires_live_source: "no"
     assert: *functional_asserts
@@ -115,6 +148,8 @@ tests:
   # ── Functional: Simulation ───────────────────────────────────────────
   - vars:
       case_file: cases/functional/simulation-01.txt
+      reference_files:
+        - references/simulation.md
       workflow: simulation
       requires_live_source: "no"
     assert: *functional_asserts
@@ -122,6 +157,10 @@ tests:
   # ── Functional: HTTP Client ─────────────────────────────────────────
   - vars:
       case_file: cases/functional/http-client-01.txt
+      reference_files:
+        - references/http-client.md
+        - references/workflow-patterns.md
+        - references/concepts.md
       workflow: http-client
       requires_live_source: "no"
     metadata:
@@ -132,6 +171,8 @@ tests:
 
   - vars:
       case_file: cases/functional/http-client-02.txt
+      reference_files:
+        - references/http-client.md
       workflow: http-client
       requires_live_source: "no"
     assert: *functional_asserts
@@ -139,6 +180,9 @@ tests:
   # ── Functional: EVM Client ──────────────────────────────────────────
   - vars:
       case_file: cases/functional/evm-client-01.txt
+      reference_files:
+        - references/evm-client.md
+        - references/concepts.md
       workflow: evm-client
       requires_live_source: "no"
     metadata:
@@ -149,6 +193,8 @@ tests:
 
   - vars:
       case_file: cases/functional/evm-client-02.txt
+      reference_files:
+        - references/evm-client.md
       workflow: evm-client
       requires_live_source: "no"
     assert: *functional_asserts
@@ -156,6 +202,9 @@ tests:
   # ── Functional: Triggers ────────────────────────────────────────────
   - vars:
       case_file: cases/functional/triggers-01.txt
+      reference_files:
+        - references/triggers.md
+        - references/workflow-patterns.md
       workflow: triggers
       requires_live_source: "no"
     metadata:
@@ -167,6 +216,10 @@ tests:
   # ── Functional: Secrets ─────────────────────────────────────────────
   - vars:
       case_file: cases/functional/secrets-01.txt
+      reference_files:
+        - references/workflow-patterns.md
+        - references/simulation.md
+        - references/operations.md
       workflow: secrets
       requires_live_source: "no"
     metadata:
@@ -178,6 +231,11 @@ tests:
   # ── Functional: Getting Started ─────────────────────────────────────
   - vars:
       case_file: cases/functional/getting-started-01.txt
+      reference_files:
+        - references/getting-started.md
+        - references/cli-reference.md
+        - references/project-scaffolding.md
+        - references/simulation.md
       workflow: getting-started
       requires_live_source: "no"
     assert: *functional_asserts
@@ -185,6 +243,8 @@ tests:
   # ── Functional: Operations ──────────────────────────────────────────
   - vars:
       case_file: cases/functional/operations-01.txt
+      reference_files:
+        - references/operations.md
       workflow: operations
       requires_live_source: "no"
     assert: *functional_asserts
@@ -192,6 +252,9 @@ tests:
   # ── Functional: Concepts ────────────────────────────────────────────
   - vars:
       case_file: cases/functional/concepts-01.txt
+      reference_files:
+        - references/concepts.md
+        - references/http-client.md
       workflow: concepts
       requires_live_source: "no"
     metadata:
@@ -202,6 +265,9 @@ tests:
 
   - vars:
       case_file: cases/functional/concepts-02.txt
+      reference_files:
+        - references/concepts.md
+        - references/workflow-patterns.md
       workflow: concepts
       requires_live_source: "no"
     assert: *functional_asserts
@@ -209,6 +275,10 @@ tests:
   # ── Functional: Feedback Loop ───────────────────────────────────────
   - vars:
       case_file: cases/functional/feedback-no-offer-01.txt
+      reference_files:
+        - references/triggers.md
+        - references/workflow-patterns.md
+        - references/evm-client.md
       workflow: feedback
       requires_live_source: "no"
     metadata:
@@ -219,6 +289,10 @@ tests:
 
   - vars:
       case_file: cases/functional/feedback-url-fallback-01.txt
+      reference_files:
+        - references/feedback.md
+        - references/cli-reference.md
+        - references/operations.md
       workflow: feedback
       requires_live_source: "no"
     metadata:
@@ -230,6 +304,10 @@ tests:
   # ── Trigger Positive ───────────────────────────────────────────────
   - vars:
       case_file: cases/trigger-positive/workflow-gen-01.txt
+      reference_files:
+        - references/project-scaffolding.md
+        - references/http-client.md
+        - references/evm-client.md
       workflow: workflow-generation
       expected_trigger: "yes"
     metadata:
@@ -240,12 +318,17 @@ tests:
 
   - vars:
       case_file: cases/trigger-positive/http-client-01.txt
+      reference_files:
+        - references/http-client.md
+        - references/concepts.md
       workflow: http-client
       expected_trigger: "yes"
     assert: *trigger_positive_asserts
 
   - vars:
       case_file: cases/trigger-positive/evm-client-01.txt
+      reference_files:
+        - references/evm-client.md
       workflow: evm-client
       expected_trigger: "yes"
     metadata:
@@ -256,30 +339,43 @@ tests:
 
   - vars:
       case_file: cases/trigger-positive/triggers-01.txt
+      reference_files:
+        - references/triggers.md
       workflow: triggers
       expected_trigger: "yes"
     assert: *trigger_positive_asserts
 
   - vars:
       case_file: cases/trigger-positive/cli-01.txt
+      reference_files:
+        - references/getting-started.md
+        - references/cli-reference.md
+        - references/project-scaffolding.md
       workflow: cli
       expected_trigger: "yes"
     assert: *trigger_positive_asserts
 
   - vars:
       case_file: cases/trigger-positive/secrets-01.txt
+      reference_files:
+        - references/workflow-patterns.md
       workflow: secrets
       expected_trigger: "yes"
     assert: *trigger_positive_asserts
 
   - vars:
       case_file: cases/trigger-positive/concepts-01.txt
+      reference_files:
+        - references/concepts.md
       workflow: concepts
       expected_trigger: "yes"
     assert: *trigger_positive_asserts
 
   - vars:
       case_file: cases/trigger-positive/operations-01.txt
+      reference_files:
+        - references/operations.md
+        - references/simulation.md
       workflow: operations
       expected_trigger: "yes"
     assert: *trigger_positive_asserts
@@ -287,6 +383,10 @@ tests:
   # ── Trigger Positive: Feedback Loop ─────────────────────────────────
   - vars:
       case_file: cases/trigger-positive/feedback-gap-01.txt
+      reference_files:
+        - references/feedback.md
+        - references/cli-reference.md
+        - references/simulation.md
       workflow: feedback
       expected_trigger: "yes"
     metadata:
@@ -297,6 +397,9 @@ tests:
 
   - vars:
       case_file: cases/trigger-positive/feedback-pain-01.txt
+      reference_files:
+        - references/feedback.md
+        - references/workflow-patterns.md
       workflow: feedback
       expected_trigger: "yes"
     metadata:
@@ -308,6 +411,7 @@ tests:
   # ── Trigger Negative ───────────────────────────────────────────────
   - vars:
       case_file: cases/trigger-negative/ccip-01.txt
+      reference_files: []
       workflow: none
       expected_trigger: "no"
     metadata:
@@ -318,6 +422,7 @@ tests:
 
   - vars:
       case_file: cases/trigger-negative/data-feeds-01.txt
+      reference_files: []
       workflow: none
       expected_trigger: "no"
     metadata:
@@ -328,30 +433,35 @@ tests:
 
   - vars:
       case_file: cases/trigger-negative/vrf-01.txt
+      reference_files: []
       workflow: none
       expected_trigger: "no"
     assert: *trigger_negative_asserts
 
   - vars:
       case_file: cases/trigger-negative/automation-01.txt
+      reference_files: []
       workflow: none
       expected_trigger: "no"
     assert: *trigger_negative_asserts
 
   - vars:
       case_file: cases/trigger-negative/functions-01.txt
+      reference_files: []
       workflow: none
       expected_trigger: "no"
     assert: *trigger_negative_asserts
 
   - vars:
       case_file: cases/trigger-negative/generic-solidity-01.txt
+      reference_files: []
       workflow: none
       expected_trigger: "no"
     assert: *trigger_negative_asserts
 
   - vars:
       case_file: cases/trigger-negative/neutral-monitoring-agent-01.txt
+      reference_files: []
       workflow: none
       expected_trigger: "no"
     metadata:

--- a/evals/chainlink-cre-skill/prompts/with-skill.js
+++ b/evals/chainlink-cre-skill/prompts/with-skill.js
@@ -1,15 +1,10 @@
-const fs = require("fs");
 const path = require("path");
+const withSkillPrompt = require("../../shared/with-skill-prompt");
 
 module.exports = function ({ vars }) {
-  const caseFile = vars.case_file;
-  const content = fs.readFileSync(path.resolve(__dirname, "..", caseFile), "utf8").trim();
-
-  const skillPath = path.resolve(__dirname, "..", "..", "..", "chainlink-cre-skill", "SKILL.md");
-  const skillContent = fs.readFileSync(skillPath, "utf8").trim();
-
-  return [
-    { role: "system", content: skillContent },
-    { role: "user", content: content },
-  ];
+  return withSkillPrompt({
+    skillId: "chainlink-cre-skill",
+    evalDir: path.resolve(__dirname, ".."),
+    vars,
+  });
 };

--- a/evals/chainlink-data-feeds-skill/promptfooconfig.yaml
+++ b/evals/chainlink-data-feeds-skill/promptfooconfig.yaml
@@ -65,6 +65,9 @@ tests:
   # ── Functional: Reading Price Feeds ──────────────────────────────────
   - vars:
       case_file: cases/functional/reading-price-feeds-01.txt
+      reference_files:
+        - references/reading-price-feeds.md
+        - references/official-sources.md
       workflow: reading-price-feeds
       requires_live_source: "yes"
     metadata:
@@ -75,18 +78,25 @@ tests:
 
   - vars:
       case_file: cases/functional/reading-price-feeds-02.txt
+      reference_files:
+        - references/reading-price-feeds.md
       workflow: reading-price-feeds
       requires_live_source: "no"
     assert: *functional_asserts
 
   - vars:
       case_file: cases/functional/reading-price-feeds-03.txt
+      reference_files:
+        - references/reading-price-feeds.md
+        - references/feed-operations.md
       workflow: reading-price-feeds
       requires_live_source: "no"
     assert: *functional_asserts
 
   - vars:
       case_file: cases/functional/reading-price-feeds-04.txt
+      reference_files:
+        - references/reading-price-feeds.md
       workflow: reading-price-feeds
       requires_live_source: "no"
     assert: *functional_asserts
@@ -94,6 +104,8 @@ tests:
   # ── Functional: MVR Feeds ────────────────────────────────────────────
   - vars:
       case_file: cases/functional/mvr-feeds-01.txt
+      reference_files:
+        - references/mvr-feeds.md
       workflow: mvr-feeds
       requires_live_source: "no"
     metadata:
@@ -104,6 +116,8 @@ tests:
 
   - vars:
       case_file: cases/functional/mvr-feeds-02.txt
+      reference_files:
+        - references/mvr-feeds.md
       workflow: mvr-feeds
       requires_live_source: "no"
     assert: *functional_asserts
@@ -111,6 +125,8 @@ tests:
   # ── Functional: SVR Feeds ────────────────────────────────────────────
   - vars:
       case_file: cases/functional/svr-feeds-01.txt
+      reference_files:
+        - references/svr-feeds.md
       workflow: svr-feeds
       requires_live_source: "no"
     metadata:
@@ -122,6 +138,8 @@ tests:
   # ── Functional: Feed Types ───────────────────────────────────────────
   - vars:
       case_file: cases/functional/feed-types-01.txt
+      reference_files:
+        - references/feed-types.md
       workflow: feed-types
       requires_live_source: "no"
     assert: *functional_asserts
@@ -129,6 +147,8 @@ tests:
   # ── Functional: Multi-Chain ──────────────────────────────────────────
   - vars:
       case_file: cases/functional/multi-chain-01.txt
+      reference_files:
+        - references/multi-chain.md
       workflow: multi-chain
       requires_live_source: "no"
     metadata:
@@ -139,6 +159,8 @@ tests:
 
   - vars:
       case_file: cases/functional/multi-chain-02.txt
+      reference_files:
+        - references/multi-chain.md
       workflow: multi-chain
       requires_live_source: "no"
     assert: *functional_asserts
@@ -146,12 +168,18 @@ tests:
   # ── Functional: Feed Operations ──────────────────────────────────────
   - vars:
       case_file: cases/functional/feed-operations-01.txt
+      reference_files:
+        - references/feed-operations.md
+        - references/reading-price-feeds.md
       workflow: feed-operations
       requires_live_source: "no"
     assert: *functional_asserts
 
   - vars:
       case_file: cases/functional/feed-operations-02.txt
+      reference_files:
+        - references/feed-operations.md
+        - references/official-sources.md
       workflow: feed-operations
       requires_live_source: "yes"
     assert: *functional_asserts
@@ -159,6 +187,14 @@ tests:
   # ── Functional: Starter Kit ──────────────────────────────────────────
   - vars:
       case_file: cases/functional/starter-kit-01.txt
+      reference_files:
+        - templates/starter-kit/README.md
+        - templates/starter-kit/foundry.toml
+        - templates/starter-kit/remappings.txt
+        - templates/starter-kit/src/PriceFeedConsumer.sol
+        - templates/starter-kit/script/PriceFeedConsumer.s.sol
+        - templates/starter-kit/test/PriceFeedConsumer.t.sol
+        - templates/starter-kit/test/mocks/MockV3Aggregator.sol
       workflow: starter-kit
       requires_live_source: "no"
     metadata:
@@ -169,6 +205,14 @@ tests:
 
   - vars:
       case_file: cases/functional/starter-kit-02.txt
+      reference_files:
+        - templates/starter-kit/README.md
+        - templates/starter-kit/foundry.toml
+        - templates/starter-kit/remappings.txt
+        - templates/starter-kit/src/PriceFeedConsumer.sol
+        - templates/starter-kit/script/PriceFeedConsumer.s.sol
+        - templates/starter-kit/test/PriceFeedConsumer.t.sol
+        - templates/starter-kit/test/mocks/MockV3Aggregator.sol
       workflow: starter-kit
       requires_live_source: "no"
     assert: *starter_kit_asserts
@@ -176,6 +220,8 @@ tests:
   # ── Trigger Positive ─────────────────────────────────────────────────
   - vars:
       case_file: cases/trigger-positive/reading-price-feeds-01.txt
+      reference_files:
+        - references/reading-price-feeds.md
       workflow: reading-price-feeds
       expected_trigger: "yes"
     metadata:
@@ -186,12 +232,16 @@ tests:
 
   - vars:
       case_file: cases/trigger-positive/reading-price-feeds-02.txt
+      reference_files:
+        - references/reading-price-feeds.md
       workflow: reading-price-feeds
       expected_trigger: "yes"
     assert: *trigger_positive_asserts
 
   - vars:
       case_file: cases/trigger-positive/mvr-01.txt
+      reference_files:
+        - references/mvr-feeds.md
       workflow: mvr-feeds
       expected_trigger: "yes"
     metadata:
@@ -202,36 +252,56 @@ tests:
 
   - vars:
       case_file: cases/trigger-positive/svr-01.txt
+      reference_files:
+        - references/svr-feeds.md
       workflow: svr-feeds
       expected_trigger: "yes"
     assert: *trigger_positive_asserts
 
   - vars:
       case_file: cases/trigger-positive/multi-chain-01.txt
+      reference_files:
+        - references/multi-chain.md
       workflow: multi-chain
       expected_trigger: "yes"
     assert: *trigger_positive_asserts
 
   - vars:
       case_file: cases/trigger-positive/feed-ops-01.txt
+      reference_files:
+        - references/feed-operations.md
+        - references/reading-price-feeds.md
       workflow: feed-operations
       expected_trigger: "yes"
     assert: *trigger_positive_asserts
 
   - vars:
       case_file: cases/trigger-positive/feed-types-01.txt
+      reference_files:
+        - references/feed-types.md
       workflow: feed-types
       expected_trigger: "yes"
     assert: *trigger_positive_asserts
 
   - vars:
       case_file: cases/trigger-positive/debugging-01.txt
+      reference_files:
+        - references/reading-price-feeds.md
+        - references/feed-operations.md
       workflow: reading-price-feeds
       expected_trigger: "yes"
     assert: *trigger_positive_asserts
 
   - vars:
       case_file: cases/trigger-positive/starter-kit-01.txt
+      reference_files:
+        - templates/starter-kit/README.md
+        - templates/starter-kit/foundry.toml
+        - templates/starter-kit/remappings.txt
+        - templates/starter-kit/src/PriceFeedConsumer.sol
+        - templates/starter-kit/script/PriceFeedConsumer.s.sol
+        - templates/starter-kit/test/PriceFeedConsumer.t.sol
+        - templates/starter-kit/test/mocks/MockV3Aggregator.sol
       workflow: starter-kit
       expected_trigger: "yes"
     metadata:
@@ -243,6 +313,7 @@ tests:
   # ── Trigger Negative ─────────────────────────────────────────────────
   - vars:
       case_file: cases/trigger-negative/ccip-01.txt
+      reference_files: []
       workflow: none
       expected_trigger: "no"
     metadata:
@@ -253,6 +324,7 @@ tests:
 
   - vars:
       case_file: cases/trigger-negative/vrf-01.txt
+      reference_files: []
       workflow: none
       expected_trigger: "no"
     metadata:
@@ -263,24 +335,28 @@ tests:
 
   - vars:
       case_file: cases/trigger-negative/automation-01.txt
+      reference_files: []
       workflow: none
       expected_trigger: "no"
     assert: *trigger_negative_asserts
 
   - vars:
       case_file: cases/trigger-negative/data-streams-01.txt
+      reference_files: []
       workflow: none
       expected_trigger: "no"
     assert: *trigger_negative_asserts
 
   - vars:
       case_file: cases/trigger-negative/functions-01.txt
+      reference_files: []
       workflow: none
       expected_trigger: "no"
     assert: *trigger_negative_asserts
 
   - vars:
       case_file: cases/trigger-negative/generic-solidity-01.txt
+      reference_files: []
       workflow: none
       expected_trigger: "no"
     assert: *trigger_negative_asserts

--- a/evals/chainlink-data-feeds-skill/prompts/with-skill.js
+++ b/evals/chainlink-data-feeds-skill/prompts/with-skill.js
@@ -1,15 +1,10 @@
-const fs = require("fs");
 const path = require("path");
+const withSkillPrompt = require("../../shared/with-skill-prompt");
 
 module.exports = function ({ vars }) {
-  const caseFile = vars.case_file;
-  const content = fs.readFileSync(path.resolve(__dirname, "..", caseFile), "utf8").trim();
-
-  const skillPath = path.resolve(__dirname, "..", "..", "..", "chainlink-data-feeds-skill", "SKILL.md");
-  const skillContent = fs.readFileSync(skillPath, "utf8").trim();
-
-  return [
-    { role: "system", content: skillContent },
-    { role: "user", content: content },
-  ];
+  return withSkillPrompt({
+    skillId: "chainlink-data-feeds-skill",
+    evalDir: path.resolve(__dirname, ".."),
+    vars,
+  });
 };

--- a/evals/chainlink-data-streams-skill/promptfooconfig.yaml
+++ b/evals/chainlink-data-streams-skill/promptfooconfig.yaml
@@ -91,6 +91,9 @@ tests:
   - description: functional / credentials / credentials-01
     vars:
       case_file: cases/functional/credentials-01.txt
+      reference_files:
+        - references/credentials-and-auth.md
+        - references/official-sources.md
       workflow: credentials
       expected_trigger: "yes"
       requires_live_source: "yes"
@@ -103,6 +106,11 @@ tests:
   - description: functional / sdk-codegen / sdk-codegen-01
     vars:
       case_file: cases/functional/sdk-codegen-01.txt
+      reference_files:
+        - references/rest-sdk.md
+        - references/websocket-sdk.md
+        - references/credentials-and-auth.md
+        - references/official-sources.md
       workflow: sdk-codegen
       expected_trigger: "yes"
       requires_live_source: "yes"
@@ -115,6 +123,10 @@ tests:
   - description: functional / onchain-verification / onchain-verification-01
     vars:
       case_file: cases/functional/onchain-verification-01.txt
+      reference_files:
+        - references/onchain-verification.md
+        - references/public-endpoints-and-addresses.md
+        - references/official-sources.md
       workflow: onchain-verification
       expected_trigger: "yes"
       requires_live_source: "yes"
@@ -127,6 +139,8 @@ tests:
   - description: trigger-positive / report-decoding / report-decoding-01
     vars:
       case_file: cases/trigger-positive/report-decoding-01.txt
+      reference_files:
+        - references/report-schemas.md
       workflow: report-decoding
       expected_trigger: "yes"
       requires_live_source: "no"
@@ -139,6 +153,8 @@ tests:
   - description: trigger-positive / websocket-ha / websocket-ha-01
     vars:
       case_file: cases/trigger-positive/websocket-ha-01.txt
+      reference_files:
+        - references/websocket-sdk.md
       workflow: websocket-ha
       expected_trigger: "yes"
       requires_live_source: "no"
@@ -151,6 +167,7 @@ tests:
   - description: trigger-negative / data-feeds / data-feeds-01
     vars:
       case_file: cases/trigger-negative/data-feeds-01.txt
+      reference_files: []
       workflow: none
       expected_trigger: "no"
       requires_live_source: "no"
@@ -163,6 +180,7 @@ tests:
   - description: trigger-negative / ccip / ccip-01
     vars:
       case_file: cases/trigger-negative/ccip-01.txt
+      reference_files: []
       workflow: none
       expected_trigger: "no"
       requires_live_source: "yes"

--- a/evals/chainlink-data-streams-skill/prompts/with-skill.js
+++ b/evals/chainlink-data-streams-skill/prompts/with-skill.js
@@ -1,15 +1,10 @@
-const fs = require("fs");
 const path = require("path");
+const withSkillPrompt = require("../../shared/with-skill-prompt");
 
 module.exports = function ({ vars }) {
-  const caseFile = vars.case_file;
-  const content = fs.readFileSync(path.resolve(__dirname, "..", caseFile), "utf8").trim();
-
-  const skillPath = path.resolve(__dirname, "..", "..", "..", "chainlink-data-streams-skill", "SKILL.md");
-  const skillContent = fs.readFileSync(skillPath, "utf8").trim();
-
-  return [
-    { role: "system", content: skillContent },
-    { role: "user", content: content },
-  ];
+  return withSkillPrompt({
+    skillId: "chainlink-data-streams-skill",
+    evalDir: path.resolve(__dirname, ".."),
+    vars,
+  });
 };

--- a/evals/chainlink-vrf-skill/promptfooconfig.yaml
+++ b/evals/chainlink-vrf-skill/promptfooconfig.yaml
@@ -53,6 +53,11 @@ tests:
       case_file: cases/functional/subscription-01.txt
       workflow: subscription
       requires_live_source: "yes"
+      reference_files:
+        - references/subscription.md
+        - references/supported-networks.md
+        - references/security-and-best-practices.md
+        - references/official-sources.md
     metadata:
       workflow: subscription
       category: functional
@@ -63,6 +68,9 @@ tests:
       case_file: cases/functional/subscription-02.txt
       workflow: subscription
       requires_live_source: "no"
+      reference_files:
+        - references/subscription.md
+        - references/billing.md
     metadata:
       workflow: subscription
       category: functional
@@ -74,6 +82,11 @@ tests:
       case_file: cases/functional/direct-funding-01.txt
       workflow: direct-funding
       requires_live_source: "yes"
+      reference_files:
+        - references/direct-funding.md
+        - references/supported-networks.md
+        - references/security-and-best-practices.md
+        - references/official-sources.md
     metadata:
       workflow: direct-funding
       category: functional
@@ -85,6 +98,10 @@ tests:
       case_file: cases/functional/migration-01.txt
       workflow: migration
       requires_live_source: "no"
+      reference_files:
+        - references/migration-from-v2.md
+        - references/subscription.md
+        - references/supported-networks.md
     metadata:
       workflow: migration
       category: functional
@@ -96,6 +113,9 @@ tests:
       case_file: cases/trigger-positive/subscription-01.txt
       workflow: subscription
       expected_trigger: "yes"
+      reference_files:
+        - references/subscription.md
+        - references/security-and-best-practices.md
     metadata:
       workflow: subscription
       category: trigger-positive
@@ -106,6 +126,9 @@ tests:
       case_file: cases/trigger-positive/legacy-trap-01.txt
       workflow: migration
       expected_trigger: "yes"
+      reference_files:
+        - references/migration-from-v2.md
+        - references/supported-networks.md
     metadata:
       workflow: migration
       category: trigger-positive
@@ -117,6 +140,7 @@ tests:
       case_file: cases/trigger-negative/data-feeds-01.txt
       workflow: none
       expected_trigger: "no"
+      reference_files: []
     metadata:
       workflow: none
       category: trigger-negative

--- a/evals/chainlink-vrf-skill/prompts/with-skill.js
+++ b/evals/chainlink-vrf-skill/prompts/with-skill.js
@@ -1,15 +1,10 @@
-const fs = require("fs");
 const path = require("path");
+const withSkillPrompt = require("../../shared/with-skill-prompt");
 
 module.exports = function ({ vars }) {
-  const caseFile = vars.case_file;
-  const content = fs.readFileSync(path.resolve(__dirname, "..", caseFile), "utf8").trim();
-
-  const skillPath = path.resolve(__dirname, "..", "..", "..", "chainlink-vrf-skill", "SKILL.md");
-  const skillContent = fs.readFileSync(skillPath, "utf8").trim();
-
-  return [
-    { role: "system", content: skillContent },
-    { role: "user", content: content },
-  ];
+  return withSkillPrompt({
+    skillId: "chainlink-vrf-skill",
+    evalDir: path.resolve(__dirname, ".."),
+    vars,
+  });
 };

--- a/evals/run-agent-eval.md
+++ b/evals/run-agent-eval.md
@@ -72,16 +72,19 @@ Read the promptfoo config at `evals/<skill>/promptfooconfig.yaml` to get the ful
 - If tier is `full`, select all tests.
 - Apply any category, workflow, or case filter on top.
 
-The case file path is in `vars.case_file` relative to the `evals/<skill>/` directory. The workflow is in `vars.workflow`.
+The case file path is in `vars.case_file` relative to the `evals/<skill>/` directory. The workflow is in `vars.workflow`. For every non-confidential test, `vars.reference_files` is an array of paths relative to the matching skill directory; it is the exact activated-skill reference context for that case.
 
 ### Step 4: Generate responses (default model)
 
 For each case file, launch a subagent that:
 
 1. Reads `<skill>/SKILL.md` in full (this is the system prompt).
-2. Reads the case file content (this is the user prompt).
-3. Generates a response as if it were an agent with that skill activated.
-4. Returns the full response text.
+2. Reads only the files listed in that test's `vars.reference_files`, resolving each path inside `<skill>/`, and appends their contents to the system prompt with a `# Reference: <path>` header.
+3. Reads the case file content (this is the user prompt).
+4. Generates a response as if it were an agent with that skill activated.
+5. Returns the full response text.
+
+Fail the run before generation if `reference_files` is absent, is not an array, contains a path outside `<skill>/`, or names a missing file. Do not load references speculatively.
 
 Use the host's default general-purpose subagent with no explicit model override for generation when possible. This evaluates the skill instructions against the user's primary selected model, reflecting real-world performance.
 

--- a/evals/shared/with-skill-prompt.js
+++ b/evals/shared/with-skill-prompt.js
@@ -1,0 +1,61 @@
+const fs = require("fs");
+const path = require("path");
+
+function readRequiredFile(filePath, description) {
+  try {
+    return fs.readFileSync(filePath, "utf8").trim();
+  } catch (error) {
+    throw new Error(`Unable to read ${description} at ${filePath}: ${error.message}`);
+  }
+}
+
+function resolveReferencePath(skillRoot, referenceFile) {
+  if (typeof referenceFile !== "string" || referenceFile.length === 0) {
+    throw new Error("vars.reference_files must contain only non-empty string paths.");
+  }
+
+  if (path.isAbsolute(referenceFile)) {
+    throw new Error(`Reference path must be relative to the skill root: ${referenceFile}`);
+  }
+
+  const resolvedPath = path.resolve(skillRoot, referenceFile);
+  const relativePath = path.relative(skillRoot, resolvedPath);
+  if (relativePath === "" || relativePath === ".." || relativePath.startsWith(`..${path.sep}`)) {
+    throw new Error(`Reference path escapes the skill root: ${referenceFile}`);
+  }
+
+  let canonicalPath;
+  try {
+    canonicalPath = fs.realpathSync(resolvedPath);
+  } catch (error) {
+    throw new Error(`Unable to resolve reference ${referenceFile}: ${error.message}`);
+  }
+
+  const canonicalRelativePath = path.relative(skillRoot, canonicalPath);
+  if (canonicalRelativePath === "" || canonicalRelativePath === ".." || canonicalRelativePath.startsWith(`..${path.sep}`)) {
+    throw new Error(`Reference path escapes the skill root: ${referenceFile}`);
+  }
+
+  return canonicalPath;
+}
+
+module.exports = function withSkillPrompt({ skillId, evalDir, vars }) {
+  if (!vars || !Array.isArray(vars.reference_files)) {
+    throw new Error("vars.reference_files must be an array.");
+  }
+
+  const casePath = path.resolve(evalDir, vars.case_file);
+  const skillRoot = fs.realpathSync(path.resolve(evalDir, "..", "..", skillId));
+  const skillPath = path.join(skillRoot, "SKILL.md");
+  const skillContent = readRequiredFile(skillPath, `${skillId} SKILL.md`);
+  const references = vars.reference_files.map((referenceFile) => {
+    const referencePath = resolveReferencePath(skillRoot, referenceFile);
+    const referenceContent = readRequiredFile(referencePath, `reference ${referenceFile}`);
+    return `# Reference: ${referenceFile}\n\n${referenceContent}`;
+  });
+
+  return [
+    { role: "system", content: [skillContent, ...references].join("\n\n") },
+    { role: "user", content: readRequiredFile(casePath, `case ${vars.case_file}`) },
+  ];
+};


### PR DESCRIPTION
## Description

Load each skill-enabled Promptfoo case with `SKILL.md` plus only its declared Progressive Disclosure references. Add explicit reference metadata for the six skill eval suites, shared prompt assembly, static validation, and aligned no-API evaluation guidance. Include the existing `.omp/` local-workspace ignore update.

## Justification

Skill-enabled Promptfoo evaluations need the same case-specific reference context required during real activated-skill workflows. Explicit metadata makes that context auditable, prevents speculative reference loading, and fails fast for missing or escaping paths.