### PR TITLE
Add cre account access to CRE skill

### DIFF
--- a/chainlink-cre-skill/SKILL.md
+++ b/chainlink-cre-skill/SKILL.md
@@ -6,7 +6,7 @@ compatibility: Designed for AI agents that implement https://agentskills.io/spec
 allowed-tools: Read WebFetch Write Edit Bash
 metadata:
   purpose: CRE developer onboarding, assistance and reference
-  version: "0.0.15"
+  version: "0.0.16"
 ---
 
 # Chainlink CRE Skill

--- a/chainlink-cre-skill/references/cli-reference.md
+++ b/chainlink-cre-skill/references/cli-reference.md
@@ -29,9 +29,13 @@ Key rules:
 
 | Flag | Description |
 |------|-------------|
-| `--help`, `-h` | Show help for any command |
-| `--version`, `-v` | Show CLI version |
-
+| `-h`, `--help` | Show help for any command |
+| `-e`, `--env <path>` | Specify the `.env` file path (default: `.env`) |
+| `-E`, `--public-env <path>` | Specify the shared, non-sensitive `.env.public` file path |
+| `-T`, `--target <name>` | Set the target environment from the project configuration |
+| `-R`, `--project-root <path>` | Specify the project root directory |
+| `-v`, `--verbose` | Enable debug logging |
+| `--non-interactive` | Fail instead of prompting; provide required inputs through flags or environment variables |
 ## Authentication Commands
 
 ### `cre login`
@@ -176,7 +180,7 @@ Prerequisites:
 - Logged in (`cre login`)
 - Wallet linked (`cre account link-key`)
 - Wallet funded with ETH for gas
-- Early Access approval
+- Early Access approval (request it with `cre account access`)
 
 ### `cre workflow activate`
 
@@ -256,6 +260,18 @@ cre workflow supported-chains --target <target-name> --output json
 ```
 
 ## Account Commands
+
+### `cre account access`
+
+Check whether the organization has deployment access. If access is not enabled, submit an Early Access request from the CLI.
+
+```bash
+cre account access
+```
+
+Requires an authenticated CLI session. Run `cre login` first. The interactive request asks for a brief description of the use case, then confirms that the request was submitted. The Chainlink team follows up by email.
+
+This command has no command-specific flags. The global flags listed above apply.
 
 ### `cre account link-key`
 

--- a/chainlink-cre-skill/references/getting-started.md
+++ b/chainlink-cre-skill/references/getting-started.md
@@ -86,6 +86,16 @@ Check authentication status:
 cre whoami
 ```
 
+### Requesting Deployment Access
+
+Deployment requires CRE Early Access approval. After logging in, run:
+
+```bash
+cre account access
+```
+
+The command checks the organization's deployment access. If access is not enabled, it prompts for a brief use-case description and submits the Early Access request. The Chainlink team follows up by email.
+
 ### API Key Authentication (CI/CD)
 
 For non-interactive environments (requires Early Access approval):

--- a/chainlink-cre-skill/references/operations.md
+++ b/chainlink-cre-skill/references/operations.md
@@ -37,7 +37,7 @@ Always include `--target`. For `cre workflow simulate` only, the CLI can also pr
 
 ### Prerequisites
 
-1. **Early Access approval**: Deployment requires being approved for the CRE Early Access program
+1. **Early Access approval**: Deployment requires approval for the CRE Early Access program. After logging in, request access with `cre account access`; it reports the organization's status and prompts for a use-case description when access is not enabled.
 2. **Authentication**: Run `cre login`; it opens a browser where the user completes the interactive sign-in (password, plus 2FA if enabled), then the agent continues
 3. **Linked wallet**: Run `cre account link-key --target <target>` to link a funded wallet
 4. **Funded wallet**: Wallet needs ETH on the target chain for gas fees


### PR DESCRIPTION
   ## Description

   Document `cre account access` as the CLI command for checking deployment access and
 submitting a CRE Early Access request. Link the deployment prerequisite and new-account
 onboarding flow to the command, and update the CRE CLI global-flags reference.

   ## Justification

   The skill previously documented Early Access approval as a deployment prerequisite without
 explaining how to request it. Agents therefore incorrectly concluded that no CLI path
 existed. This change gives agents the documented CLI workflow needed to guide users from
 account setup through deploy access.
