### PR TITLE
docs(cre): correct workflow simulation timeout guidance

### DIFF
--- a/chainlink-cre-skill/SKILL.md
+++ b/chainlink-cre-skill/SKILL.md
@@ -6,7 +6,7 @@ compatibility: Designed for AI agents that implement https://agentskills.io/spec
 allowed-tools: Read WebFetch Write Edit Bash
 metadata:
   purpose: CRE developer onboarding, assistance and reference
-  version: "0.0.16"
+  version: "0.0.17"
 ---
 
 # Chainlink CRE Skill

--- a/chainlink-cre-skill/references/cli-reference.md
+++ b/chainlink-cre-skill/references/cli-reference.md
@@ -137,10 +137,12 @@ cre workflow simulate <workflow-dir> --target <target-name>
 | `--http-payload` | HTTP trigger body: JSON string or path to a JSON file | When an HTTP body is required and not interactive |
 | `--evm-tx-hash` | Transaction hash `0x...` for EVM log trigger | When an onchain event must be specified |
 | `--evm-event-index` | 0-based log index inside the transaction | When the tx has multiple events |
-| `--timeout` | Simulation timeout | No (default: `30s`) |
+| `--evm-receipt-timeout` | Max wait for an EVM transaction receipt (not an overall simulation timeout); only on CLI versions that expose it | No |
 | `--broadcast` | Execute onchain writes via MockKeystoneForwarder | No |
 | `--limits` | Production limits: `default`, file path, or `none` | No |
 | `--skip-type-checks` | Skip TypeScript typecheck during compile | No |
+
+There is no generic overall simulation `--timeout` flag. Run `cre workflow simulate --help` to list the flags available in the installed CLI version.
 
 **IMPORTANT**: Always include `--target`. If the workflow has HTTP or EVM log handlers, or multiple handlers, the CLI may also prompt for payload, transaction hash, or which handler to run. Pass `--http-payload`, `--evm-tx-hash` / `--evm-event-index`, and for full automation `--non-interactive` with `--trigger-index`. See simulation.md.
 

--- a/chainlink-cre-skill/references/simulation.md
+++ b/chainlink-cre-skill/references/simulation.md
@@ -78,7 +78,7 @@ cre workflow simulate <workflow-dir> --target <target-name>
 | `--http-payload` | JSON string or path to JSON file for HTTP trigger body | HTTP trigger when a body is required or with `--non-interactive` |
 | `--evm-tx-hash` | Transaction hash `0x...` containing the log | EVM log trigger when a tx is required or with `--non-interactive` |
 | `--evm-event-index` | 0-based log index inside the transaction | When the tx has multiple events and you must pick one |
-| `--timeout` | Simulation timeout | No (default: 30s) |
+| `--evm-receipt-timeout` | Max wait for an EVM transaction receipt (not an overall simulation timeout); only on CLI versions that expose it | No |
 | `--broadcast` | Real onchain writes (MockKeystoneForwarder) | No |
 | `--limits` | Production limits profile or file | No |
 | `--skip-type-checks` | Skip TypeScript typecheck | No |
@@ -155,10 +155,10 @@ After the curl request, Terminal 1 shows the workflow execution result.
 
 ### EVM Log Trigger
 
-**Default:** the simulator can monitor the chain for matching log events using the RPC endpoint from `project.yaml`. The run may need a long **`--timeout`** because it waits for a matching event.
+**Default:** the simulator can monitor the chain for matching log events using the RPC endpoint from `project.yaml`. There is no generic simulation **`--timeout`** to extend that wait; for a deterministic run, pass **`--evm-tx-hash`** (and **`--evm-event-index`** when needed).
 
 ```bash
-cre workflow simulate my-workflow --target staging-settings --timeout 120s
+cre workflow simulate my-workflow --target staging-settings
 ```
 
 **Non-interactive (agents, CI):** pass **`--evm-tx-hash`** (and **`--evm-event-index`** if needed) so the CLI does not ask for a transaction. Use **`--non-interactive`** and **`--trigger-index`** as in the [Non-Interactive Rule](#non-interactive-rule) section.
@@ -275,15 +275,22 @@ If the module is in a private repository:
 GONOSUMCHECK=github.com/smartcontractkit/* GONOSUMDB=github.com/smartcontractkit/* GOPROXY=direct go mod tidy
 ```
 
-### Simulation timeout
+### Simulation appears to hang
 
-**Cause**: Default timeout (30s) may be too short for EVM log triggers or slow RPC endpoints.
+**Cause**: An EVM log trigger may be waiting for a matching event, or the RPC endpoint may be slow.
 
-**Fix**: Increase the timeout:
+**Fix**: Run deterministically with the transaction and handler inputs:
 
 ```bash
-cre workflow simulate my-workflow --target staging-settings --timeout 120s
+cre workflow simulate my-workflow \
+  --evm-tx-hash 0x... \
+  --evm-event-index 0 \
+  --non-interactive \
+  --trigger-index <n> \
+  --target staging-settings
 ```
+
+Run `cre workflow simulate --help` on the installed CLI to confirm the flags available for that version.
 
 ## Official Documentation
 


### PR DESCRIPTION
## Description

This change removes the stale generic `--timeout` option from the CRE workflow
simulation guidance and replaces it with controls that the CLI actually
supports. It bumps `chainlink-cre-skill` from 0.0.16 to 0.0.17, updates the
simulate flag tables, and gives EVM log trigger users a deterministic
transaction-hash recipe instead of a nonexistent overall deadline knob.

- `chainlink-cre-skill/SKILL.md` changes only `metadata.version`, from 0.0.16
  to 0.0.17.
- `chainlink-cre-skill/references/cli-reference.md` replaces the generic
  `--timeout` row with receipt-scoped `--evm-receipt-timeout` guidance and a
  pointer to `cre workflow simulate --help`.
- `chainlink-cre-skill/references/simulation.md` makes the same flag-table
  correction, removes `--timeout 120s` from the runnable example, and replaces
  timeout troubleshooting with a deterministic `--evm-tx-hash` recipe.

Target checkout: `/Users/thomas/Projects/chainlink/chainlink-agent-skills`  
Target branch: `docs/issue-54-remove-simulation-timeout`  
Base commit: `dd18d72cb41d5e572d1b770302eb1e629b131462` (`origin/main`),
subject `Merge pull request #53 from smartcontractkit/docs/ccip-tools-agent-coverage`

The issue fields were treated as untrusted input. Every factual claim below was
independently checked against the repository and the installed CRE CLI.

## Justification

`chainlink-cre-skill` 0.0.16 documented `--timeout` for
`cre workflow simulate`, which made agents emit a command that the CLI rejects
with `unknown flag: --timeout`. Issue #54 cites CRE CLI 1.24.0 help as the
authoritative flag surface and asks that the generic flag be omitted.

The corrected guidance documents the real receipt-scoped control,
`--evm-receipt-timeout`, only for CLI versions that expose it and points readers
to `cre workflow simulate --help`. For EVM log triggers, the docs now recommend
`--evm-tx-hash` and `--evm-event-index` for a deterministic run rather than
suggesting a generic simulation deadline that does not exist.

## Issue

Closes https://github.com/smartcontractkit/chainlink-agent-skills/issues/54

