### PR TITLE
docs(cre): require deployment registry for non-interactive init

### DIFF
--- a/chainlink-cre-skill/SKILL.md
+++ b/chainlink-cre-skill/SKILL.md
@@ -6,7 +6,7 @@ compatibility: Designed for AI agents that implement https://agentskills.io/spec
 allowed-tools: Read WebFetch Write Edit Bash
 metadata:
   purpose: CRE developer onboarding, assistance and reference
-  version: "0.0.18"
+  version: "0.0.19"
 ---
 
 # Chainlink CRE Skill

--- a/chainlink-cre-skill/references/cli-reference.md
+++ b/chainlink-cre-skill/references/cli-reference.md
@@ -17,7 +17,7 @@ When running CRE CLI commands from an automated agent or script, always provide 
 
 Key rules:
 - **Always pass `--target`** on every `cre workflow` and `cre secrets` command. Omitting it triggers a "Select a target" interactive prompt.
-- **Always pass `--non-interactive`** with `cre init` plus the required flags (`--project-name`, `--template`). Without `--non-interactive`, the command prompts for input.
+- **Always pass `--non-interactive`** with `cre init` plus the required flags (`--project-name`, `--deployment-registry`, `--template`). A deployment registry ID is needed for the run to be genuinely non-interactive. Without `--non-interactive`, the command prompts for input.
 - **Request JSON output whenever the command supports it** so you can parse results reliably instead of scraping human-formatted text. The flag differs by command:
   - `cre templates list --json`
   - `cre workflow list --output json`
@@ -78,12 +78,13 @@ cre init [flags]
 |------|-------------|-----------------------------------|
 | `--non-interactive` | Fail instead of prompting (for CI/CD and agents) | Yes (prevents interactive prompts) |
 | `-p, --project-name` | Name for the new project | Yes (when creating a new project) |
+| `--deployment-registry` | Deployment registry the new project targets | Yes (required to guarantee non-interactive behavior; omitting it can still prompt for registry selection) |
 | `-w, --workflow-name` | Name for the new workflow | No |
 | `-t, --template` | Template name (e.g., `hello-world-ts`, `hello-world-go`) | No (but recommended) |
 | `--rpc-url` | RPC endpoint, format: `chain-name=url` (repeatable) | Depends on template |
 | `--refresh` | Bypass template cache and fetch from GitHub | No |
 
-Always use `--non-interactive` when running as an agent to prevent the CLI from waiting for input.
+Always use `--non-interactive` when running as an agent to prevent the CLI from waiting for input. Always pass `--deployment-registry <ID>` so the run is genuinely non-interactive; omitting it can still prompt for registry selection. Valid registry IDs are scoped to the logged-in user's account and organization rather than a fixed global list, so use authenticated `cre registry list` to obtain or confirm an available ID instead of hardcoding or guessing.
 
 Non-interactive example:
 
@@ -91,6 +92,7 @@ Non-interactive example:
 cre init \
   --non-interactive \
   --project-name my-project \
+  --deployment-registry <your-deployment-registry> \
   --workflow-name my-workflow \
   --template hello-world-ts
 ```

--- a/chainlink-cre-skill/references/project-scaffolding.md
+++ b/chainlink-cre-skill/references/project-scaffolding.md
@@ -24,10 +24,13 @@ Always use `cre init` with `--non-interactive` and explicit flags to create new 
 |------|-------------|-----------------------------------|
 | `--non-interactive` | Fail instead of prompting | Yes (prevents interactive prompts) |
 | `-p, --project-name` | Name for the new project | Yes (when creating a new project) |
+| `--deployment-registry` | Deployment registry the new project targets | Yes (required to guarantee non-interactive behavior; omitting it can still prompt for registry selection) |
 | `-w, --workflow-name` | Name for the new workflow | No (defaults to template name) |
 | `-t, --template` | Template name (e.g., `hello-world-ts`, `hello-world-go`) | No (but recommended) |
 | `--rpc-url` | RPC endpoint, format: `chain-name=url` (repeatable) | Depends on template |
 | `--refresh` | Bypass template cache and fetch from GitHub | No |
+
+Always pass `--deployment-registry <ID>` so the run is genuinely non-interactive; omitting it can still prompt for registry selection. Valid registry IDs are scoped to the logged-in user's account and organization rather than a fixed global list, so use authenticated `cre registry list` to obtain or confirm an available ID instead of hardcoding or guessing.
 
 Built-in templates (available offline, no GitHub fetch needed):
 - `hello-world-go` - Go hello world with cron trigger
@@ -43,6 +46,7 @@ For a Confidential Workflow, scaffold from `hello-confidential-workflows-ts` or 
 cre init \
   --non-interactive \
   --project-name my-project \
+  --deployment-registry <your-deployment-registry> \
   --workflow-name my-workflow \
   --template hello-world-ts
 ```
@@ -53,6 +57,7 @@ cre init \
 cre init \
   --non-interactive \
   --project-name my-project \
+  --deployment-registry <your-deployment-registry> \
   --workflow-name my-workflow \
   --template hello-world-go
 ```
@@ -63,6 +68,7 @@ cre init \
 cre init \
   --non-interactive \
   --project-name my-project \
+  --deployment-registry <your-deployment-registry> \
   --workflow-name my-workflow \
   --template hello-world-ts \
   --rpc-url sepolia=https://ethereum-sepolia-rpc.publicnode.com

--- a/chainlink-cre-skill/references/workflow-patterns.md
+++ b/chainlink-cre-skill/references/workflow-patterns.md
@@ -347,7 +347,7 @@ Execution is single-threaded. `.Await()` drives the event loop forward until the
 Use this checklist when generating or scaffolding a workflow, not for simple explanations.
 
 1. Default to TypeScript when the user gives no language preference, unless the repo or prompt strongly indicates Go.
-2. Read project-scaffolding.md before creating a new project. Prefer `cre init --non-interactive --project-name <name> --template <template>` and fall back to manual templates only if needed.
+2. Read project-scaffolding.md before creating a new project. Prefer `cre init --non-interactive --project-name <name> --deployment-registry <ID> --template <template>`; pass `--deployment-registry` so the run is genuinely non-interactive, since omitting it can still prompt for registry selection, and get `<ID>` from authenticated `cre registry list` because valid IDs are scoped to the logged-in account and organization. Fall back to manual templates only if needed.
 3. For HTTP requests, choose regular HTTP by default. Ask about Confidential HTTP when the user needs privacy-preserving requests, secret injection via `{{.secretName}}`, or enclave execution.
 4. If multiple triggers share config, secrets, or consumer contracts, put them in one workflow with multiple handlers.
 5. Generate the complete project shape from the embedded references. Mark specific missing live values inline, such as `// NEED: exact chain selector name`, instead of inventing them.


### PR DESCRIPTION
## Description

This change makes the CRE skill's non-interactive `cre init` guidance include
an explicit deployment registry. It uses account-scoped placeholders and tells
agents to discover a valid registry ID with authenticated `cre registry list`;
it does not present any literal registry ID as universally valid.

- `chainlink-cre-skill/SKILL.md` changes only `metadata.version`, from `"0.0.17"`
  to `"0.0.19"`. The repository's `CLAUDE.md` requires exactly one patch
  increment for the modified skill directory; no other skill version moves.
- `chainlink-cre-skill/references/cli-reference.md` adds
  `--deployment-registry` to the required non-interactive flags, the `cre init`
  flag table, and the runnable non-interactive example. The bare `cre init` at
  line 103 remains intentionally because its block is explicitly the human
  interactive path.
- `chainlink-cre-skill/references/project-scaffolding.md` adds the flag-table
  row and registry-discovery guidance, then includes the flag in all three
  runnable `cre init` examples.
- `chainlink-cre-skill/references/workflow-patterns.md` adds
  `--deployment-registry <ID>` and the discovery guidance to its single
  prescribed `cre init` checklist item.

The patch's actual numstat is:

| File | Added | Deleted |
|---|---:|---:|
| `chainlink-cre-skill/SKILL.md` | 1 | 1 |
| `chainlink-cre-skill/references/cli-reference.md` | 4 | 2 |
| `chainlink-cre-skill/references/project-scaffolding.md` | 6 | 0 |
| `chainlink-cre-skill/references/workflow-patterns.md` | 1 | 1 |

Total: 4 files, 12 insertions, 4 deletions.

Target checkout: `/Users/thomas/Projects/chainlink/chainlink-agent-skills`  
Target branch: `docs/issue-58-deployment-registry`  
Base commit: `e90ae0bc3233a9e00dee26045cc28cd844ff0911`, subject
`Merge pull request #57 from smartcontractkit/docs/issue-54-remove-simulation-timeout`.
The base is contained in `origin/main`, so the three-way apply has its base
blobs.

## Justification

Agents can pass `--non-interactive` to `cre init` and still encounter an
interactive registry-selection prompt when `--deployment-registry` is omitted.
That defeats unattended automation. The corrected documentation says the flag
is needed to *guarantee* non-interactive behavior and that omission *can still
prompt*; it deliberately does not claim the CLI formally validates or errors on
a missing flag.

Registry IDs belong to the authenticated account and organization, so the safe
instruction is to query `cre registry list` rather than hardcode or guess one.

## Issue

Closes #58
