### PR TITLE
docs(cre): allow mainnet lookup in EVM examples

### DIFF
--- a/chainlink-cre-skill/SKILL.md
+++ b/chainlink-cre-skill/SKILL.md
@@ -6,7 +6,7 @@ compatibility: Designed for AI agents that implement https://agentskills.io/spec
 allowed-tools: Read WebFetch Write Edit Bash
 metadata:
   purpose: CRE developer onboarding, assistance and reference
-  version: "0.0.19"
+  version: "0.0.20"
 ---
 
 # Chainlink CRE Skill

--- a/chainlink-cre-skill/references/evm-client.md
+++ b/chainlink-cre-skill/references/evm-client.md
@@ -51,7 +51,6 @@ const onCronTrigger = (runtime: Runtime<Config>): string => {
   const network = getNetwork({
     chainFamily: "evm",
     chainSelectorName: runtime.config.chainSelectorName,
-    isTestnet: true,
   })
   if (!network) {
     throw new Error(`Unknown chain selector name: ${runtime.config.chainSelectorName}`)
@@ -266,7 +265,6 @@ const onCronTrigger = (runtime: Runtime<Config>): string => {
   const network = getNetwork({
     chainFamily: "evm",
     chainSelectorName: runtime.config.chainSelectorName,
-    isTestnet: true,
   })
   if (!network) {
     throw new Error(`Unknown chain selector name: ${runtime.config.chainSelectorName}`)


### PR DESCRIPTION
## Description

This documentation change makes the CRE EVM client examples resolve networks
from a configured selector name without forcing testnet-only lookup behavior.

| File | Insertions | Deletions | Change |
|---|---:|---:|---|
| `chainlink-cre-skill/SKILL.md` | 1 | 1 | Bump skill metadata from 0.0.19 to 0.0.20. |
| `chainlink-cre-skill/references/evm-client.md` | 0 | 2 | Remove `isTestnet: true` from the Onchain Reads and Full Write Flow `getNetwork` examples. |
| **Total: 2 files** | **1** | **3** | |


## Justification

In the published CRE SDK v1.16.0 package, `isTestnet` is optional
(`network-lookup.d.ts:3-6`). For a family-and-name lookup,
`isTestnet === true` searches only `testnetByNameByFamily`
(`network-lookup.js:37-43`). When the field is omitted, lookup first checks the
testnet map and then falls back to `mainnetByNameByFamily`
(`network-lookup.js:44-48`).

`polygon-mainnet` has zero testnet records and exactly one mainnet record. The
hardcoded testnet restriction therefore left the reported Polygon-mainnet
scenario unresolved and caused the intact `!network` guard to throw. Omitting
the optional field is the correct network-type-unrestricted behavior for a
configuration-driven `chainSelectorName`, and is sufficient to make the
mainnet record resolvable.

## Issue

Closes #59
