### PR TITLE
docs(cre): fix Go EVM client examples to match cre-sdk-go API

### DIFF
--- a/chainlink-cre-skill/SKILL.md
+++ b/chainlink-cre-skill/SKILL.md
@@ -6,7 +6,7 @@ compatibility: Designed for AI agents that implement https://agentskills.io/spec
 allowed-tools: Read WebFetch Write Edit Bash
 metadata:
   purpose: CRE developer onboarding, assistance and reference
-  version: "0.0.20"
+  version: "0.0.21"
 ---
 
 # Chainlink CRE Skill

--- a/chainlink-cre-skill/references/evm-client.md
+++ b/chainlink-cre-skill/references/evm-client.md
@@ -103,54 +103,91 @@ export async function main() {
 package main
 
 import (
+    "fmt"
+    "log/slog"
     "math/big"
-    "github.com/smartcontractkit/cre-sdk-go/cre"
+
+    "my-project/contracts/evm/src/generated/storage"
+
+    "github.com/ethereum/go-ethereum/common"
+    "github.com/smartcontractkit/cre-sdk-go/capabilities/blockchain/evm"
     "github.com/smartcontractkit/cre-sdk-go/capabilities/scheduler/cron"
-    "my-project/contracts/evm/src/abi"
+    "github.com/smartcontractkit/cre-sdk-go/cre"
+    "github.com/smartcontractkit/cre-sdk-go/cre/wasm"
 )
 
 type Config struct {
-    Schedule          string `json:"schedule"`
-    ContractAddress   string `json:"contractAddress"`
-    ChainSelectorName string `json:"chainSelectorName"`
+    Schedule        string `json:"schedule"`
+    ContractAddress string `json:"contractAddress"`
+    ChainSelector   uint64 `json:"chainSelector"`
 }
 
 type Result struct {
-    Price string `json:"price"`
+    Value string `json:"value"`
 }
 
 func onCronTrigger(config *Config, runtime cre.Runtime, trigger *cron.Payload) (*Result, error) {
-    evmClient := runtime.EVMClient()
+    evmClient := &evm.Client{ChainSelector: config.ChainSelector}
+    contractAddress := common.HexToAddress(config.ContractAddress)
 
-    binding := abi.NewAggregatorV3Interface(
-        config.ContractAddress,
-        config.ChainSelectorName,
-        evmClient,
-    )
-
-    result, err := binding.LatestRoundData(big.NewInt(-3)).Await()
+    binding, err := storage.NewStorage(evmClient, contractAddress, nil)
     if err != nil {
-        return nil, err
+        return nil, fmt.Errorf("create Storage binding: %w", err)
     }
 
-    return &Result{Price: result.Answer.String()}, nil
+    value, err := binding.Get(runtime, big.NewInt(-3)).Await()
+    if err != nil {
+        return nil, fmt.Errorf("read storage value: %w", err)
+    }
+
+    return &Result{Value: value.String()}, nil
 }
 
-func InitWorkflow(config *Config) []cre.HandlerDefinition {
-    return []cre.HandlerDefinition{
-        cre.Handler(cron.Trigger(cron.Config{Schedule: config.Schedule}), onCronTrigger),
-    }
+func InitWorkflow(config *Config, logger *slog.Logger, secretsProvider cre.SecretsProvider) (cre.Workflow[*Config], error) {
+    return cre.Workflow[*Config]{
+        cre.Handler(
+            cron.Trigger(&cron.Config{Schedule: config.Schedule}),
+            onCronTrigger,
+        ),
+    }, nil
+}
+
+func main() {
+    wasm.NewRunner(cre.ParseJSON[Config]).Run(InitWorkflow)
 }
 ```
 
 ### Block Number Options
 
+#### TypeScript
+
 | Value | Description |
 |-------|-------------|
-| `0n` / `big.NewInt(0)` | Last finalized block (default, recommended) |
-| `-1n` / `big.NewInt(-1)` | Latest known block (not finalized) |
-| `-2n` / `big.NewInt(-2)` | Safe block |
-| `-3n` / `big.NewInt(-3)` | Pending block |
+| `0n` | Last finalized block (default, recommended) |
+| `-1n` | Latest known block (not finalized) |
+| `-2n` | Safe block |
+| `-3n` | Pending block |
+| Positive value | Specific block number |
+
+#### Go
+
+**Generated bindings (`binding.Method(runtime, ..., blockNumber)`)**
+
+| Value | Description |
+|-------|-------------|
+| `big.NewInt(-3)` | Finalized block (recommended for production) |
+| `big.NewInt(-2)` | Latest known block |
+| `nil` | Finalized block (default) |
+| Positive value | Specific block number |
+
+Generated read methods substitute `bindings.FinalizedBlockNumber` when `blockNumber` is `nil`.
+
+**Low-level `evm.Client` calls (`CallContract`, `BalanceAt`, `HeaderByNumber` — `BlockNumber *pb.BigInt`)**
+
+| Value | Description |
+|-------|-------------|
+| `nil` or `-2` | Latest known block (default) |
+| `-3` | Finalized block |
 | Positive value | Specific block number |
 
 ### ABI Encoding/Decoding (TypeScript)
@@ -182,8 +219,8 @@ Use `bigint` (not `number`) for all Solidity integer types to avoid precision lo
 ### Writing Data Workflow
 
 1. **ABI-encode** the data you want to write
-2. **Generate a signed report** using `runtime.report()`
-3. **Submit the report** using `evmClient.writeReport()`
+2. **Generate a signed report** using `runtime.report()` in TypeScript (`runtime.GenerateReport()` in Go)
+3. **Submit the report** using `evmClient.writeReport()` in TypeScript (a generated `WriteReportFrom<StructName>` helper or `evmClient.WriteReport()` in Go)
 
 ### TypeScript: Encoding Single Values
 
@@ -315,86 +352,137 @@ export async function main() {
 package main
 
 import (
+    "fmt"
+    "log/slog"
     "math/big"
+
+    calculator_consumer "my-project/contracts/evm/src/generated/calculator_consumer"
+
     "github.com/ethereum/go-ethereum/accounts/abi"
-    "github.com/smartcontractkit/cre-sdk-go/cre"
+    "github.com/ethereum/go-ethereum/common"
+    "github.com/smartcontractkit/cre-sdk-go/capabilities/blockchain/evm"
     "github.com/smartcontractkit/cre-sdk-go/capabilities/scheduler/cron"
+    "github.com/smartcontractkit/cre-sdk-go/cre"
+    "github.com/smartcontractkit/cre-sdk-go/cre/wasm"
 )
 
 type Config struct {
-    Schedule          string `json:"schedule"`
-    ConsumerAddress   string `json:"consumerAddress"`
-    ChainSelectorName string `json:"chainSelectorName"`
+    Schedule        string `json:"schedule"`
+    ConsumerAddress string `json:"consumerAddress"`
+    ChainSelector   uint64 `json:"chainSelector"`
+    GasLimit        uint64 `json:"gasLimit"`
 }
 
 func onCronTrigger(config *Config, runtime cre.Runtime, trigger *cron.Payload) (*string, error) {
-    evmClient := runtime.EVMClient()
+    evmClient := &evm.Client{ChainSelector: config.ChainSelector}
+    consumerAddress := common.HexToAddress(config.ConsumerAddress)
 
-    uint256Type, _ := abi.NewType("uint256", "", nil)
+    consumerContract, err := calculator_consumer.NewCalculatorConsumer(evmClient, consumerAddress, nil)
+    if err != nil {
+        return nil, fmt.Errorf("create CalculatorConsumer binding: %w", err)
+    }
+
+    gasConfig := &evm.GasConfig{GasLimit: config.GasLimit}
+    writePromise := consumerContract.WriteReportFromCalculatorResult(runtime, calculator_consumer.CalculatorResult{
+        OffchainValue: big.NewInt(20000000000),
+        OnchainValue:  big.NewInt(22000000000),
+        FinalResult:   big.NewInt(42000000000),
+    }, gasConfig)
+
+    resp, err := writePromise.Await()
+    if err != nil {
+        return nil, fmt.Errorf("write generated report: %w", err)
+    }
+
+    txHash := common.BytesToHash(resp.TxHash).Hex()
+    return &txHash, nil
+}
+
+func writeReportExplicit(runtime cre.Runtime, evmClient *evm.Client, consumerAddress common.Address, gasLimit uint64) (string, error) {
+    uint256Type, err := abi.NewType("uint256", "", nil)
+    if err != nil {
+        return "", fmt.Errorf("create uint256 ABI type: %w", err)
+    }
     args := abi.Arguments{{Type: uint256Type}}
     encoded, err := args.Pack(big.NewInt(42000000000))
     if err != nil {
-        return nil, err
+        return "", fmt.Errorf("encode report payload: %w", err)
     }
 
-    signedReport := runtime.Report(encoded)
-
-    txResult, err := evmClient.WriteReport(cre.WriteReportConfig{
-        ToAddress:         config.ConsumerAddress,
-        ChainSelectorName: config.ChainSelectorName,
-        Report:            signedReport,
-        GasLimit:          big.NewInt(500000),
+    report, err := runtime.GenerateReport(&cre.ReportRequest{
+        EncodedPayload: encoded,
+        EncoderName:    "evm",
+        SigningAlgo:    "ecdsa",
+        HashingAlgo:    "keccak256",
     }).Await()
     if err != nil {
-        return nil, err
+        return "", fmt.Errorf("generate report: %w", err)
     }
 
-    result := txResult.TxHash
-    return &result, nil
+    resp, err := evmClient.WriteReport(runtime, &evm.WriteCreReportRequest{
+        Receiver:  consumerAddress.Bytes(),
+        Report:    report,
+        GasConfig: &evm.GasConfig{GasLimit: gasLimit},
+    }).Await()
+    if err != nil {
+        return "", fmt.Errorf("write report: %w", err)
+    }
+
+    return common.BytesToHash(resp.TxHash).Hex(), nil
 }
 
-func InitWorkflow(config *Config) []cre.HandlerDefinition {
-    return []cre.HandlerDefinition{
-        cre.Handler(cron.Trigger(cron.Config{Schedule: config.Schedule}), onCronTrigger),
-    }
+func InitWorkflow(config *Config, logger *slog.Logger, secretsProvider cre.SecretsProvider) (cre.Workflow[*Config], error) {
+    return cre.Workflow[*Config]{
+        cre.Handler(
+            cron.Trigger(&cron.Config{Schedule: config.Schedule}),
+            onCronTrigger,
+        ),
+    }, nil
+}
+
+func main() {
+    wasm.NewRunner(cre.ParseJSON[Config]).Run(InitWorkflow)
 }
 ```
+
+The binding generator creates a `WriteReportFrom<StructName>` helper named after each ABI input struct. That helper performs the ABI encoding, `runtime.GenerateReport()`, and `evmClient.WriteReport()` steps for you.
 
 ### TxStatus Values
 
-| Status | Description |
-|--------|-------------|
-| `Success` | Transaction confirmed and successful |
-| `Reverted` | Transaction was reverted on chain |
-| `Pending` | Transaction is pending confirmation |
-| `FatalError` | Unrecoverable error |
+| Go | TypeScript | Description |
+|----|------------|-------------|
+| `evm.TxStatus_TX_STATUS_SUCCESS` | `TxStatus.SUCCESS` | Transaction confirmed and successful |
+| `evm.TxStatus_TX_STATUS_REVERTED` | `TxStatus.REVERTED` | Transaction was reverted onchain |
+| `evm.TxStatus_TX_STATUS_FATAL` | `TxStatus.FATAL` | Transaction failed with an unrecoverable error |
 
 ### Gas Configuration
 
-Default gas limit is 500,000. Override per-write with the `gasLimit` parameter.
+In Go, pass `&evm.GasConfig{GasLimit: <uint64>}` to the write call, or pass `nil` to accept the default. In TypeScript, set the per-write limit with `gasConfig.gasLimit`.
 
 ## Go Binding Generation
 
-Generate type-safe Go bindings from Solidity ABI files:
+Place raw ABI arrays (`*.abi`) or compiled contract artifacts (`*.json`) in `contracts/evm/src/abi/`, then generate the bindings:
 
 ```bash
-cre generate-bindings --abi-dir contracts/evm/src/abi --pkg abi --output contracts/evm/src/abi
+cre generate-bindings evm
 ```
 
-Place ABI JSON files in the `contracts/evm/src/abi/` directory:
-
-```
-contracts/evm/src/abi/
-├── AggregatorV3Interface.json
-└── MyContract.json
-```
-
-Generated bindings provide type-safe methods that return `Promise` objects:
+Generated Go packages land under `contracts/evm/src/generated/`. Constructors return the binding and an error, and generated read methods take the runtime first:
 
 ```go
-binding := abi.NewMyContract(address, chainSelector, evmClient)
-result, err := binding.MyMethod(arg1, arg2).Await()
+evmClient := &evm.Client{ChainSelector: config.ChainSelector}
+address := common.HexToAddress(config.ContractAddress)
+binding, err := my_contract.NewMyContract(evmClient, address, nil)
+if err != nil {
+    return nil, fmt.Errorf("create MyContract binding: %w", err)
+}
+result, err := binding.MyMethod(runtime, my_contract.MyMethodInput{
+    Arg1: arg1,
+    Arg2: arg2,
+}, big.NewInt(-3)).Await()
 ```
+
+Methods with no ABI inputs omit the `args` parameter entirely.
 
 ## Consumer Contracts
 
@@ -697,3 +785,5 @@ const display = formatUnits(1000000000000000000n, 18)
 - Onchain write: `https://docs.chain.link/cre/guides/workflow/using-evm-client/onchain-write/writing-data-onchain.md`
 - Consumer contracts: `https://docs.chain.link/cre/guides/workflow/using-evm-client/onchain-write/building-consumer-contracts.md`
 - Forwarder addresses: `https://docs.chain.link/cre/guides/workflow/using-evm-client/forwarder-directory-ts.md`
+- Go binding generation: `https://docs.chain.link/cre/guides/workflow/using-evm-client/generating-bindings-go.md`
+- Go EVM client SDK reference: `https://docs.chain.link/cre/reference/sdk/evm-client-go.md`

--- a/chainlink-cre-skill/references/sdk-reference.md
+++ b/chainlink-cre-skill/references/sdk-reference.md
@@ -408,8 +408,7 @@ Package: `github.com/smartcontractkit/cre-sdk-go`
 | `Now()` | `time.Time` | Consensus-derived timestamp |
 | `Rand()` | `(*rand.Rand, error)` | Consensus-safe random source |
 | `GetSecret(name string)` | `(string, error)` | Retrieve a secret |
-| `Report(data []byte)` | `SignedReport` | Generate signed report |
-| `EVMClient()` | `EVMClient` | Access the EVM client |
+| `GenerateReport(*cre.ReportRequest)` | `Promise[*cre.Report]` | Generate a signed report from the DON |
 
 #### `cre.NodeRuntime`
 
@@ -423,7 +422,10 @@ Available inside `RunInNodeMode` callbacks:
 #### `cre.Handler(trigger, callback)`
 
 ```go
-cre.Handler(trigger TriggerDefinition, callback HandlerFunc) HandlerDefinition
+cre.Handler[C any, M proto.Message, T any, O any](
+    trigger Trigger[M, T],
+    callback func(config C, runtime cre.Runtime, payload T) (O, error),
+) ExecutionHandler[C, Runtime]
 ```
 
 #### `cre.HandlerInTee(trigger, callback, tees)` and `cre.TeeRuntime`
@@ -458,26 +460,51 @@ Asynchronous result wrapper.
 ### EVM Client API (Go)
 
 ```go
-evmClient := runtime.EVMClient()
+import "github.com/smartcontractkit/cre-sdk-go/capabilities/blockchain/evm"
+
+evmClient := &evm.Client{ChainSelector: config.ChainSelector}
 ```
+
+`ChainSelector` is a `uint64`. Use `evm.ChainSelectorFromName(name)` to resolve a chain selector name first.
 
 #### Generated Bindings
 
 ```go
-binding := abi.NewMyContract(address, chainSelector, evmClient)
-result, err := binding.MyMethod(args...).Await()
+contractAddress := common.HexToAddress(config.ContractAddress)
+binding, err := my_contract.NewMyContract(evmClient, contractAddress, nil)
+if err != nil {
+    return nil, fmt.Errorf("create MyContract binding: %w", err)
+}
+result, err := binding.MyMethod(runtime, my_contract.MyMethodInput{Arg1: arg1, Arg2: arg2}, blockNumber).Await()
 ```
 
 #### WriteReport
 
+Generate a report, then submit it through the EVM client:
+
 ```go
-txResult, err := evmClient.WriteReport(cre.WriteReportConfig{
-    ToAddress:         string,
-    ChainSelectorName: string,
-    Report:            SignedReport,
-    GasLimit:          *big.Int,
+report, err := runtime.GenerateReport(&cre.ReportRequest{
+    EncodedPayload: encoded,
+    EncoderName:    "evm",
+    SigningAlgo:    "ecdsa",
+    HashingAlgo:    "keccak256",
+}).Await()
+if err != nil {
+    return nil, err
+}
+
+resp, err := evmClient.WriteReport(runtime, &evm.WriteCreReportRequest{
+    Receiver:  consumerAddress.Bytes(),
+    Report:    report,
+    GasConfig: &evm.GasConfig{GasLimit: gasLimit},
 }).Await()
 ```
+
+The stable low-level signature is `WriteReport(runtime cre.Runtime, input *evm.WriteCreReportRequest) cre.Promise[*evm.WriteReportReply]`. `evm.WriteCreReportRequest` contains `Receiver []byte`, `Report *cre.Report`, and optional `GasConfig *evm.GasConfig`; `evm.GasConfig.GasLimit` is a `uint64`.
+
+`evm.WriteReportReply` contains `TxStatus TxStatus`, `ReceiverContractExecutionStatus *ReceiverContractExecutionStatus`, `TxHash []byte`, `TransactionFee *pb.BigInt`, and `ErrorMessage *string`. `TxStatus` is one of `evm.TxStatus_TX_STATUS_SUCCESS`, `evm.TxStatus_TX_STATUS_REVERTED`, or `evm.TxStatus_TX_STATUS_FATAL`.
+
+Prefer the generated helper for ABI structs: the generator creates a `WriteReportFrom<StructName>(runtime, data, gasConfig)` method named after each input struct, which performs the encoding, `runtime.GenerateReport()`, and client `WriteReport()` calls.
 
 ### HTTP Client API (Go)
 
@@ -498,7 +525,7 @@ result, err := httpClient.RunInNodeMode(runtime, fetchFn, aggregation).Await()
 ```go
 import "github.com/smartcontractkit/cre-sdk-go/capabilities/scheduler/cron"
 
-cron.Trigger(cron.Config{Schedule: "*/30 * * * * *"})
+cron.Trigger(&cron.Config{Schedule: "*/30 * * * * *"})
 ```
 
 Callback: `func(config *Config, runtime cre.Runtime, trigger *cron.Payload) (*Result, error)`


### PR DESCRIPTION
## Description

Rewrite the Go EVM read and write examples against the published
`cre-sdk-go` API surface and official CRE documentation. The previous
examples were a mistaken port of the TypeScript surface and referenced
`runtime.EVMClient()`, `runtime.Report()`, and `cre.WriteReportConfig`,
which exist in no published Go release.

The replacement examples are complete `package main` programs using
`&evm.Client{...}`, `runtime.GenerateReport`,
`evm.WriteCreReportRequest` or a generated binding's `WriteReport`
method, and `&evm.GasConfig`. The change also corrects the Go EVM SDK
reference and runtime-method table. TypeScript code blocks are unchanged.

The skill metadata patch version moves from `0.0.20` to `0.0.21`, as
required by the repository's `CLAUDE.md` when a skill directory changes.

## Justification

Users following the Go examples could not use the documented symbols
because those symbols are not exported by a published `cre-sdk-go`
release. The corrected examples now align with the real Go SDK surface,
the `cre-cli` generator template, and official CRE documentation.

The update also makes the two Go entry points match the current runner
contract, passes generated-binding read arguments as one input struct,
uses qualified transaction-status enums, and documents the distinct
generated-binding and low-level-client block-number semantics.

## Issue

Closes #48
